### PR TITLE
Add Bis TV on Hot Bird

### DIFF
--- a/AutoBouquetsMaker/custom/README.txt
+++ b/AutoBouquetsMaker/custom/README.txt
@@ -278,6 +278,9 @@ Provider key: cable_nl
 Provider name: Virgin (UK)
 Provider key: cable_uk_virgin
 
+Provider name: Bis TV (Hot Bird) (FR)
+Provider key: sat_130_bistv
+
 Provider name: Sky Italia
 Provider key: sat_130_sky_italy
 
@@ -299,7 +302,7 @@ Provider key: sat_192_canal_plus_esp
 Provider name: Sky Deutschland
 Provider key: sat_192_sky_deutschland
 
-Provider name: TÈlÈSAT
+Provider name: T√©l√©SAT
 Provider key: sat_192_telesat
 
 Provider name: TNTSat

--- a/AutoBouquetsMaker/providers/sat_130_bistv.xml
+++ b/AutoBouquetsMaker/providers/sat_130_bistv.xml
@@ -1,0 +1,28 @@
+<provider>
+	<name>Bis TV</name>
+	<streamtype>dvbs</streamtype>
+	<protocol>lcnbat</protocol>
+	<transponder
+		orbital_position="130"
+		frequency="11681000"
+		symbol_rate="27500000"
+		polarization="0"
+		fec_inner="3"
+		inversion="2"
+		system="1"
+		modulation="2"
+		roll_off="0"
+		pilot="2"
+		bat_pid="0x11"
+	/>
+	<sections>
+		<section number="1">Bis TV</section>
+	</sections>
+	<dvbsconfigs>
+		<configuration key="hd_00306" bouquet="0x0132" region="0x83">Hot Bird</configuration>
+	</dvbsconfigs>
+	<servicehacks>
+<![CDATA[
+]]>
+	</servicehacks>
+</provider>


### PR DESCRIPTION
This provides a bouquet for the French subscription service Bis TV on Hot Bird at 13°E. A slightly different version of the package is also provided on Eutelsat 5 West A.