### PR TITLE
Update TNT SAT bouquet

### DIFF
--- a/AutoBouquetsMaker/providers/sat_192_tntsat.xml
+++ b/AutoBouquetsMaker/providers/sat_192_tntsat.xml
@@ -1,43 +1,27 @@
 <provider>
-	<name>TNTSat</name>
+	<name>TNT SAT</name>
 	<streamtype>dvbs</streamtype>
 	<protocol>lcnbat2</protocol>
 	<transponder
 		orbital_position="192"
-		frequency="11856000"		
-		symbol_rate="27500000"
+		frequency="11856000"
+		symbol_rate="29700000"
 		polarization="1"
-		fec_inner="0"
+		fec_inner="4"
 		inversion="2"
-		system="0"
+		system="1"
 		modulation="1"
 		roll_off="0"
 		pilot="2"
 		bat_pid="0x11"
+		nit_other_table_id="0x00"
 	/>
 	<sections>
 		<section number="1">Chaines</section>
 		<section number="300">Regionales</section>
 	</sections>
 	<dvbsconfigs>
-		<!--<configuration key="hd_49153" bouquet="0xc001" region="0x83">CanalSatellite</configuration>--><!-- empty -->
-		<!--<configuration key="hd_49157" bouquet="0xc005" region="0x83">TNTSAT</configuration>--><!-- 26 channels -->
-		<!--<configuration key="hd_49162" bouquet="0xc00a" region="0x83">TNTSAT HD</configuration>--><!-- 29 channels -->
-		<!--<configuration key="hd_49163" bouquet="0xc00b" region="0x83">TNTSAT SPS</configuration>--><!-- empty -->
-		<!--<configuration key="hd_49164" bouquet="0xc00c" region="0x83">TNTSAT C1</configuration>--><!-- 1 info channel -->
-		<!--<configuration key="hd_49165" bouquet="0xc00d" region="0x83">CanalSat HD</configuration>--><!-- 271 channels -->
-		<!--<configuration key="sd_49166" bouquet="0xc00e" region="0x83">TNTSAT SD</configuration>--><!-- 53 channels -->
-		<configuration key="hd_49167" bouquet="0xc00f" region="0x83">TNTSAT HD</configuration><!-- 53 channels -->
-		<!--<configuration key="hd_49169" bouquet="0xc011" region="0x83">Hospitality Ref</configuration>--><!-- empty -->
-		<!--<configuration key="hd_49170" bouquet="0xc012" region="0x83">TNT TRIAX</configuration>--><!-- empty -->
-		<!--<configuration key="hd_49171" bouquet="0xc013" region="0x83">TNTSAT pro</configuration>--><!-- 49 channels -->
-		<!--<configuration key="hd_49172" bouquet="0xc014" region="0x83">REDSAT BASIC</configuration>--><!-- 90 channels -->
-		<!--<configuration key="hd_49173" bouquet="0xc015" region="0x83">REDSAT CPLUS</configuration>--><!-- 98 channels -->
-		<!--<configuration key="hd_49174" bouquet="0xc016" region="0x83">REDSAT CSAT</configuration>--><!-- 271 channels -->
-		<!--<configuration key="hd_49180" bouquet="0xc01c" region="0x83">CANAL READY SUISSE</configuration>--><!-- 100+ channels -->
-		<!--<configuration key="hd_49181" bouquet="0xc01d" region="0x83">CANAL PRO Phase 2</configuration>--><!-- empty -->
-		<!--<configuration key="hd_49182" bouquet="0xc01e" region="0x83">CANAL+ R7 Prod</configuration>--><!-- 20 channels -->
-		<!--<configuration key="hd_49183" bouquet="0xc01f" region="0x83">CANAL+ R7 Test</configuration>--><!-- 20 channels -->
+		<configuration key="hd_49167" bouquet="0xc00f" region="0x83">TNT SAT</configuration>
 	</dvbsconfigs>
 	<servicehacks>
 <![CDATA[


### PR DESCRIPTION
- Update transponder settings to reflect recent satellite change

- Disable nit_other_table scanning to improve speed

- Capitalize and space bouquet name correctly to match official branding