### PR TITLE
Update CanalSat France bouquet

### DIFF
--- a/AutoBouquetsMaker/providers/sat_192_canalsat.xml
+++ b/AutoBouquetsMaker/providers/sat_192_canalsat.xml
@@ -1,19 +1,20 @@
 <provider>
-	<name>CanalSat FR</name>
+	<name>CanalSat France</name>
 	<streamtype>dvbs</streamtype>
 	<protocol>lcnbat2</protocol>
 	<transponder
 		orbital_position="192"
-		frequency="11856000"		
-		symbol_rate="27500000"
+		frequency="11856000"
+		symbol_rate="29700000"
 		polarization="1"
-		fec_inner="0"
+		fec_inner="4"
 		inversion="2"
-		system="0"
+		system="1"
 		modulation="1"
 		roll_off="0"
 		pilot="2"
 		bat_pid="0x11"
+		nit_other_table_id="0x00"
 	/>
 	<sections>
 		<section number="1">Chaines</section>
@@ -21,7 +22,7 @@
 		<section number="400">Autres</section>
 	</sections>
 	<dvbsconfigs>
-		<configuration key="hd_49165" bouquet="0xc00d" region="0x83">CanalSat HD</configuration><!-- 271 channels -->
+		<configuration key="hd_49165" bouquet="0xc00d" region="0x83">CanalSat France</configuration>
 	</dvbsconfigs>
 	<servicehacks>
 <![CDATA[


### PR DESCRIPTION
- Update transponder settings to reflect recent satellite change

- Disable nit_other_table scanning to improve speed