### PR TITLE
Add sections and more services to HD+ bouquet

### DIFF
--- a/AutoBouquetsMaker/custom/README.txt
+++ b/AutoBouquetsMaker/custom/README.txt
@@ -284,6 +284,9 @@ Provider key: sat_282_freesat
 Provider name: FreeView (UK)
 Provider key: terrestrial_uk_freeview
 
+Provider name: HD+ (DE)
+Provider key: sat_0192_hd+
+
 Provider name: Kabel (NL)
 Provider key: cable_nl
 

--- a/AutoBouquetsMaker/custom/hd_sat_0192_hd+_CustomLCN.xml
+++ b/AutoBouquetsMaker/custom/hd_sat_0192_hd+_CustomLCN.xml
@@ -1,6 +1,7 @@
 <custom>
 	<include>yes</include>
 	<lcnlist>
+		<!-- Vollprogramme -->
 		<configuration lcn="1" channelnumber="10301" description="Das Erste HD"></configuration>
 		<configuration lcn="2" channelnumber="11110" description="ZDF HD"></configuration>
 		<configuration lcn="3" channelnumber="61200" description="RTL HD"></configuration>
@@ -10,106 +11,218 @@
 		<configuration lcn="7" channelnumber="61302" description="kabel eins HD"></configuration>
 		<configuration lcn="8" channelnumber="11150" description="3sat HD"></configuration>
 		<configuration lcn="9" channelnumber="10302" description="arte HD"></configuration>
-		<configuration lcn="10" channelnumber="28487" description="ARD-alpha"></configuration>
-		<configuration lcn="11" channelnumber="10376" description="ONE HD"></configuration>
-		<configuration lcn="12" channelnumber="11130" description="zdf_neo HD"></configuration>
-		<configuration lcn="13" channelnumber="11160" description="KiKA HD"></configuration>
-		<configuration lcn="14" channelnumber="11931" description="SUPER RTL HD"></configuration>
-		<configuration lcn="15" channelnumber="21107" description="NICKELODEON HD"></configuration>
-		<configuration lcn="16" channelnumber="5500" description="Disney Channel HD"></configuration>
-		<configuration lcn="17" channelnumber="61205" description="RTLII HD"></configuration>
-		<configuration lcn="18" channelnumber="21100" description="ANIXE HD"></configuration>
-		<configuration lcn="19" channelnumber="5401" description="TELE 5 HD"></configuration>
-		<configuration lcn="20" channelnumber="11951" description="RTLNITRO HD"></configuration>
-		<configuration lcn="21" channelnumber="61304" description="Pro7 MAXX HD"></configuration>
-		<configuration lcn="22" channelnumber="12500" description="SAT.1 Gold HD"></configuration>
-		<configuration lcn="23" channelnumber="61303" description="SIXX HD"></configuration>
-		<configuration lcn="24" channelnumber="10101" description="Zee One HD"></configuration>
-		<configuration lcn="25" channelnumber="10100" description="TLC HD"></configuration>
-		<configuration lcn="26" channelnumber="4914" description="ServusTV HD Deutschland"></configuration>
-		<configuration lcn="27" channelnumber="5010" description="INSIGHT TV HD"></configuration>
-		<configuration lcn="28" channelnumber="5402" description="DMAX HD"></configuration>
-		<configuration lcn="29" channelnumber="11170" description="ZDFinfo HD"></configuration>
-		<configuration lcn="30" channelnumber="10375" description="tagesschau24 HD"></configuration>
-		<configuration lcn="31" channelnumber="10331" description="PHOENIX HD"></configuration>
-		<configuration lcn="32" channelnumber="21108" description="N24 HD"></configuration>
-		<configuration lcn="33" channelnumber="61204" description="n-tv HD"></configuration>
-		<configuration lcn="34" channelnumber="5505" description="SPORT1 HD"></configuration>
-		<configuration lcn="35" channelnumber="12502" description="Eurosport 1 HD"></configuration>
-		<configuration lcn="36" channelnumber="5503" description="Deluxe Music HD"></configuration>
-		<configuration lcn="37" channelnumber="10103" description="MTV HD"></configuration>
-		<configuration lcn="38" channelnumber="10326" description="BR Fernsehen Nord HD"></configuration>
-		<configuration lcn="39" channelnumber="10325" description="BR Fernsehen Sd HD"></configuration>
-		<configuration lcn="40" channelnumber="10355" description="hr-fernsehen HD"></configuration>
-		<configuration lcn="41" channelnumber="10352" description="MDR Sachsen HD"></configuration>
-		<configuration lcn="42" channelnumber="10353" description="MDR S-Anhalt HD"></configuration>
-		<configuration lcn="43" channelnumber="10354" description="MDR Thüringen HD"></configuration>
-		<configuration lcn="44" channelnumber="10329" description="NDR FS HH HD"></configuration>
-		<configuration lcn="45" channelnumber="10328" description="NDR FS MV HD"></configuration>
-		<configuration lcn="46" channelnumber="10327" description="NDR FS NDS HD"></configuration>
-		<configuration lcn="47" channelnumber="10330" description="NDR FS SH HD"></configuration>
-		<configuration lcn="48" channelnumber="28385" description="Radio Bremen TV"></configuration>
-		<configuration lcn="49" channelnumber="10351" description="rbb Berlin HD"></configuration>
-		<configuration lcn="50" channelnumber="10350" description="rbb Brandenburg HD"></configuration>
-		<configuration lcn="51" channelnumber="10378" description="SR Fernsehen HD"></configuration>
-		<configuration lcn="52" channelnumber="10303" description="SWR BW HD"></configuration>
-		<configuration lcn="53" channelnumber="10304" description="SWR RP HD"></configuration>
-		<configuration lcn="54" channelnumber="28325" description="WDR HD Köln"></configuration>
-		<configuration lcn="55" channelnumber="28544" description="WDR HD Aachen"></configuration>
-		<configuration lcn="56" channelnumber="28326" description="WDR HD Bielefeld"></configuration>
-		<configuration lcn="57" channelnumber="28546" description="WDR HD Bonn"></configuration>
-		<configuration lcn="58" channelnumber="28327" description="WDR HD Dortmund"></configuration>
-		<configuration lcn="59" channelnumber="28328" description="WDR HD Düsseldorf"></configuration>
-		<configuration lcn="60" channelnumber="28547" description="WDR HD Duisburg"></configuration>
-		<configuration lcn="61" channelnumber="28329" description="WDR HD Essen"></configuration>
-		<configuration lcn="62" channelnumber="28330" description="WDR HD Münster"></configuration>
-		<configuration lcn="63" channelnumber="28331" description="WDR HD Siegen"></configuration>
-		<configuration lcn="64" channelnumber="28545" description="WDR HD Wuppertal"></configuration>
-		<configuration lcn="65" channelnumber="12501" description="Fashion 4K Preview"></configuration>
-		<configuration lcn="66" channelnumber="10104" description="Channel21 HD"></configuration>
-		<configuration lcn="67" channelnumber="21104" description="HSE24 HD"></configuration>
-		<configuration lcn="68" channelnumber="5501" description="HSE24 EXTRA HD"></configuration>
-		<configuration lcn="69" channelnumber="5403" description="Juwelo HD"></configuration>
-		<configuration lcn="70" channelnumber="10102" description="mediaspar HD"></configuration>
-		<configuration lcn="71" channelnumber="5404" description="pearl.tv HD Shop"></configuration>
-		<configuration lcn="72" channelnumber="5400" description="sonnenklar.TV HD"></configuration>
-		<configuration lcn="73" channelnumber="21103" description="QVC HD"></configuration>
-		<configuration lcn="74" channelnumber="10105" description="QVC BEAUTY + STYLE HD"></configuration>
-		<configuration lcn="75" channelnumber="5504" description="QVC PLUS HD"></configuration>
-		<configuration lcn="76" channelnumber="5502" description="1-2-3.tv HD"></configuration>
-		<configuration lcn="77" channelnumber="13224" description="Bibel TV HD"></configuration>
-		<configuration lcn="78" channelnumber="13227" description="HOPE Channel HD"></configuration>
-		<configuration lcn="79" channelnumber="13019" description="RiC"></configuration>
-		<configuration lcn="80" channelnumber="12604" description="Deutsches Musik Fernsehen"></configuration>
-		<configuration lcn="81" channelnumber="13018" description="Folx TV"></configuration>
-		<configuration lcn="82" channelnumber="13021" description="gotv"></configuration>
-		<configuration lcn="83" channelnumber="13013" description="HITRADIO OE3"></configuration>
-		<configuration lcn="84" channelnumber="13015" description="Mei Musi TV"></configuration>
-		<configuration lcn="85" channelnumber="13229" description="MELODIE TV"></configuration>
-		<configuration lcn="86" channelnumber="12634" description="nice"></configuration>
-		<configuration lcn="87" channelnumber="13222" description="Volksmusik"></configuration>
-		<configuration lcn="88" channelnumber="4601" description="Franken Fernsehen"></configuration>
-		<configuration lcn="89" channelnumber="4602" description="intv"></configuration>
-		<configuration lcn="90" channelnumber="4690" description="Lokal TV Portal"></configuration>
-		<configuration lcn="91" channelnumber="4606" description="Mainfranken"></configuration>
-		<configuration lcn="92" channelnumber="4604" description="münchen.tv"></configuration>
-		<configuration lcn="93" channelnumber="4609" description="Niederbayern"></configuration>
-		<configuration lcn="94" channelnumber="12614" description="rhein main tv"></configuration>
-		<configuration lcn="95" channelnumber="4605" description="rfo Regional Oberbayern"></configuration>
-		<configuration lcn="96" channelnumber="4607" description="TV Oberfranken"></configuration>
-		<configuration lcn="97" channelnumber="4608" description="TVA-OTV"></configuration>
-		<configuration lcn="98" channelnumber="4603" description="Ulm-Allgäu"></configuration>
-		<configuration lcn="99" channelnumber="12600" description="collection"></configuration>
-		<configuration lcn="100" channelnumber="21113" description="Genius Plus"></configuration>
-		<configuration lcn="101" channelnumber="12633" description="Shop24Direct"></configuration>
-		<configuration lcn="102" channelnumber="12601" description="K-TV"></configuration>
-		<configuration lcn="103" channelnumber="21112" description="SOPHIA TV"></configuration>
-		<configuration lcn="104" channelnumber="13014" description="ORF2E"></configuration>
-		<configuration lcn="105" channelnumber="4600" description="a.tv"></configuration>
-		<configuration lcn="106" channelnumber="13226" description="Starparadies AT"></configuration>
-		<configuration lcn="107" channelnumber="13225" description="Schau TV"></configuration>
-		<configuration lcn="108" channelnumber="5031" description="Al Jazeera English HD"></configuration>
-		<configuration lcn="109" channelnumber="5001" description="BBC World News Europe HD"></configuration>
-		<configuration lcn="110" channelnumber="5021" description="NHK World TV"></configuration>
+		<!-- Kinder -->
+		<configuration lcn="10" channelnumber="11160" description="KiKA HD"></configuration>
+		<configuration lcn="11" channelnumber="11931" description="SUPER RTL HD"></configuration>
+		<configuration lcn="12" channelnumber="5500" description="Disney Channel HD"></configuration>
+		<configuration lcn="13" channelnumber="21107" description="NICKELODEON HD"></configuration>
+		<configuration lcn="14" channelnumber="12030" description="TOGGO plus"></configuration>
+		<configuration lcn="15" channelnumber="13019" description="RiC"></configuration>
+		<!-- Unterhaltung -->
+		<configuration lcn="16" channelnumber="10376" description="ONE HD"></configuration>
+		<configuration lcn="17" channelnumber="11130" description="zdf_neo HD"></configuration>
+		<configuration lcn="18" channelnumber="61205" description="RTLII HD"></configuration>
+		<configuration lcn="19" channelnumber="21100" description="ANIXE HD"></configuration>
+		<configuration lcn="20" channelnumber="5401" description="TELE 5 HD"></configuration>
+		<configuration lcn="21" channelnumber="11951" description="RTLNITRO HD"></configuration>
+		<configuration lcn="22" channelnumber="61304" description="Pro7 MAXX HD"></configuration>
+		<configuration lcn="23" channelnumber="12500" description="SAT.1 Gold HD"></configuration>
+		<configuration lcn="24" channelnumber="61303" description="SIXX HD"></configuration>
+		<configuration lcn="25" channelnumber="10101" description="Zee One HD"></configuration>
+		<configuration lcn="26" channelnumber="764" description="ANIXE SD"></configuration>
+		<configuration lcn="27" channelnumber="12080" description="RTLplus"></configuration>
+		<configuration lcn="28" channelnumber="33" description="Family TV"></configuration>
+		<!-- Doku -->
+		<configuration lcn="29" channelnumber="10100" description="TLC HD"></configuration>
+		<configuration lcn="30" channelnumber="4914" description="ServusTV HD Deutschland"></configuration>
+		<configuration lcn="31" channelnumber="5010" description="INSIGHT TV HD"></configuration>
+		<configuration lcn="32" channelnumber="5402" description="DMAX HD"></configuration>
+		<configuration lcn="33" channelnumber="11170" description="ZDFinfo HD"></configuration>
+		<configuration lcn="34" channelnumber="10331" description="PHOENIX HD"></configuration>
+		<configuration lcn="35" channelnumber="28487" description="ARD-alpha"></configuration>
+		<configuration lcn="36" channelnumber="17509" description="kabel eins Doku"></configuration>
+		<configuration lcn="37" channelnumber="48" description="N24 DOKU"></configuration>
+		<configuration lcn="38" channelnumber="13103" description="Welt der Wunder"></configuration>
+		<!-- Nachrichten -->
+		<configuration lcn="39" channelnumber="10375" description="tagesschau24 HD"></configuration>
+		<configuration lcn="40" channelnumber="21108" description="N24 HD"></configuration>
+		<configuration lcn="41" channelnumber="61204" description="n-tv HD"></configuration>
+		<configuration lcn="42" channelnumber="5031" description="Al Jazeera English HD"></configuration>
+		<configuration lcn="43" channelnumber="5001" description="BBC World News Europe HD"></configuration>
+		<configuration lcn="44" channelnumber="5021" description="NHK World TV"></configuration>
+		<!-- Sport -->
+		<configuration lcn="45" channelnumber="5505" description="SPORT1 HD"></configuration>
+		<configuration lcn="46" channelnumber="12502" description="Eurosport 1 HD"></configuration>
+		<!-- Musik -->
+		<configuration lcn="47" channelnumber="5503" description="Deluxe Music HD"></configuration>
+		<configuration lcn="48" channelnumber="10103" description="MTV HD"></configuration>
+		<configuration lcn="49" channelnumber="12604" description="Deutsches Musik Fernsehen"></configuration>
+		<configuration lcn="50" channelnumber="13018" description="Folx TV"></configuration>
+		<configuration lcn="51" channelnumber="13021" description="gotv"></configuration>
+		<configuration lcn="52" channelnumber="13013" description="HITRADIO OE3"></configuration>
+		<configuration lcn="53" channelnumber="13015" description="Mei Musi TV"></configuration>
+		<configuration lcn="54" channelnumber="13229" description="MELODIE TV"></configuration>
+		<configuration lcn="55" channelnumber="12634" description="nice"></configuration>
+		<configuration lcn="56" channelnumber="13222" description="Volksmusik"></configuration>
+		<!-- Regionales -->
+		<configuration lcn="57" channelnumber="10326" description="BR Fernsehen Nord HD"></configuration>
+		<configuration lcn="58" channelnumber="10325" description="BR Fernsehen Süd HD"></configuration>
+		<configuration lcn="59" channelnumber="10355" description="hr-fernsehen HD"></configuration>
+		<configuration lcn="60" channelnumber="10352" description="MDR Sachsen HD"></configuration>
+		<configuration lcn="61" channelnumber="10353" description="MDR S-Anhalt HD"></configuration>
+		<configuration lcn="62" channelnumber="10354" description="MDR Thüringen HD"></configuration>
+		<configuration lcn="63" channelnumber="10329" description="NDR FS HH HD"></configuration>
+		<configuration lcn="64" channelnumber="10328" description="NDR FS MV HD"></configuration>
+		<configuration lcn="65" channelnumber="10327" description="NDR FS NDS HD"></configuration>
+		<configuration lcn="66" channelnumber="10330" description="NDR FS SH HD"></configuration>
+		<configuration lcn="67" channelnumber="28385" description="Radio Bremen TV"></configuration>
+		<configuration lcn="68" channelnumber="10351" description="rbb Berlin HD"></configuration>
+		<configuration lcn="69" channelnumber="10350" description="rbb Brandenburg HD"></configuration>
+		<configuration lcn="70" channelnumber="10378" description="SR Fernsehen HD"></configuration>
+		<configuration lcn="71" channelnumber="10303" description="SWR BW HD"></configuration>
+		<configuration lcn="72" channelnumber="10304" description="SWR RP HD"></configuration>
+		<configuration lcn="73" channelnumber="28325" description="WDR HD Köln"></configuration>
+		<configuration lcn="74" channelnumber="28544" description="WDR HD Aachen"></configuration>
+		<configuration lcn="75" channelnumber="28326" description="WDR HD Bielefeld"></configuration>
+		<configuration lcn="76" channelnumber="28546" description="WDR HD Bonn"></configuration>
+		<configuration lcn="77" channelnumber="28327" description="WDR HD Dortmund"></configuration>
+		<configuration lcn="78" channelnumber="28328" description="WDR HD Düsseldorf"></configuration>
+		<configuration lcn="79" channelnumber="28547" description="WDR HD Duisburg"></configuration>
+		<configuration lcn="80" channelnumber="28329" description="WDR HD Essen"></configuration>
+		<configuration lcn="81" channelnumber="28330" description="WDR HD Münster"></configuration>
+		<configuration lcn="82" channelnumber="28331" description="WDR HD Siegen"></configuration>
+		<configuration lcn="83" channelnumber="28545" description="WDR HD Wuppertal"></configuration>
+		<configuration lcn="84" channelnumber="70" description="BB-MV Lokal-TV"></configuration>
+		<configuration lcn="85" channelnumber="4601" description="Franken Fernsehen"></configuration>
+		<configuration lcn="86" channelnumber="4602" description="intv"></configuration>
+		<configuration lcn="87" channelnumber="4690" description="Lokal TV Portal"></configuration>
+		<configuration lcn="88" channelnumber="13113" description="L-TV/TVM"></configuration>
+		<configuration lcn="89" channelnumber="4606" description="Mainfranken"></configuration>
+		<configuration lcn="90" channelnumber="4604" description="münchen.tv"></configuration>
+		<configuration lcn="91" channelnumber="4609" description="Niederbayern"></configuration>
+		<configuration lcn="92" channelnumber="47" description="REGIO TV"></configuration>
+		<configuration lcn="93" channelnumber="12614" description="rhein main tv"></configuration>
+		<configuration lcn="94" channelnumber="4605" description="rfo Regional Oberbayern"></configuration>
+		<configuration lcn="95" channelnumber="4607" description="TV Oberfranken"></configuration>
+		<configuration lcn="96" channelnumber="4608" description="TVA-OTV"></configuration>
+		<configuration lcn="97" channelnumber="4603" description="Ulm-Allgäu"></configuration>
+		<configuration lcn="98" channelnumber="12006" description="RTL FS"></configuration>
+		<configuration lcn="99" channelnumber="12005" description="RTL HB NDS"></configuration>
+		<configuration lcn="100" channelnumber="12009" description="RTL HH SH"></configuration>
+		<configuration lcn="101" channelnumber="12004" description="RTL Regional NRW"></configuration>
+		<configuration lcn="102" channelnumber="17507" description="SAT.1 Bayern"></configuration>
+		<configuration lcn="103" channelnumber="17508" description="SAT.1 NRW"></configuration>
+		<!-- Einkaufen -->
+		<configuration lcn="104" channelnumber="12501" description="Fashion 4K Preview"></configuration>
+		<configuration lcn="105" channelnumber="5502" description="1-2-3.tv HD"></configuration>
+		<configuration lcn="106" channelnumber="10104" description="Channel21 HD"></configuration>
+		<configuration lcn="107" channelnumber="21104" description="HSE24 HD"></configuration>
+		<configuration lcn="108" channelnumber="5501" description="HSE24 EXTRA HD"></configuration>
+		<configuration lcn="109" channelnumber="5403" description="Juwelo HD"></configuration>
+		<configuration lcn="110" channelnumber="10102" description="mediaspar HD"></configuration>
+		<configuration lcn="111" channelnumber="5404" description="pearl.tv HD Shop"></configuration>
+		<configuration lcn="112" channelnumber="21103" description="QVC HD"></configuration>
+		<configuration lcn="113" channelnumber="10105" description="QVC BEAUTY + STYLE HD"></configuration>
+		<configuration lcn="114" channelnumber="5504" description="QVC PLUS HD"></configuration>
+		<configuration lcn="115" channelnumber="5400" description="sonnenklar.TV HD"></configuration>
+		<configuration lcn="116" channelnumber="661" description="AstroTV"></configuration>
+		<configuration lcn="117" channelnumber="54" description="Beauty TV"></configuration>
+		<configuration lcn="118" channelnumber="769" description="Channel21"></configuration>
+		<configuration lcn="119" channelnumber="897" description="e8 television"></configuration>
+		<configuration lcn="120" channelnumber="21113" description="Genius Plus"></configuration>
+		<configuration lcn="121" channelnumber="77" description="HSE24 TREND"></configuration>
+		<configuration lcn="122" channelnumber="514" description="JML Shop"></configuration>
+		<configuration lcn="123" channelnumber="775" description="MediaShop- Meine Einkaufswelt"></configuration>
+		<configuration lcn="124" channelnumber="898" description="MediaShop- Neuheiten"></configuration>
+		<configuration lcn="125" channelnumber="899" description="meinTVshop"></configuration>
+		<configuration lcn="126" channelnumber="12633" description="Shop24Direct"></configuration>
+		<configuration lcn="127" channelnumber="659" description="Sparhandy TV"></configuration>
+		<!-- Religion -->
+		<configuration lcn="128" channelnumber="13224" description="Bibel TV HD"></configuration>
+		<configuration lcn="129" channelnumber="62" description="EWTN katholisches TV"></configuration>
+		<configuration lcn="130" channelnumber="774" description="GOD Channel"></configuration>
+		<configuration lcn="131" channelnumber="13227" description="HOPE Channel HD"></configuration>
+		<configuration lcn="132" channelnumber="12601" description="K-TV"></configuration>
+		<configuration lcn="133" channelnumber="21112" description="SOPHIA TV"></configuration>
+		<!-- Österreich -->
+		<configuration lcn="134" channelnumber="13014" description="ORF2E"></configuration>
+		<configuration lcn="135" channelnumber="4600" description="a.tv"></configuration>
+		<configuration lcn="136" channelnumber="61" description="NICKELODEON AT"></configuration>
+		<configuration lcn="137" channelnumber="13102" description="RTL NITRO A"></configuration>
+		<configuration lcn="138" channelnumber="60" description="Comedy Central / VIVA AT"></configuration>
+		<configuration lcn="139" channelnumber="13106" description="sixx Austria"></configuration>
+		<configuration lcn="140" channelnumber="13111" description="ServusTV Oesterreich"></configuration>
+		<configuration lcn="141" channelnumber="73" description="DMAX Austria"></configuration>
+		<configuration lcn="142" channelnumber="53" description="N24 Austria"></configuration>
+		<configuration lcn="143" channelnumber="13225" description="Schau TV"></configuration>
+		<configuration lcn="144" channelnumber="13226" description="Starparadies AT"></configuration>
+		<configuration lcn="145" channelnumber="13141" description="BTV"></configuration>
+		<configuration lcn="146" channelnumber="13104" description="LT1-OOE"></configuration>
+		<!-- SD-Versionen -->
+		<configuration lcn="201" channelnumber="28106" description="Das Erste"></configuration>
+		<configuration lcn="202" channelnumber="28006" description="ZDF"></configuration>
+		<configuration lcn="203" channelnumber="12003" description="RTL Television"></configuration>
+		<configuration lcn="204" channelnumber="17500" description="SAT.1"></configuration>
+		<configuration lcn="205" channelnumber="12060" description="VOX"></configuration>
+		<configuration lcn="206" channelnumber="17501" description="ProSieben"></configuration>
+		<configuration lcn="207" channelnumber="17502" description="kabel eins"></configuration>
+		<configuration lcn="208" channelnumber="28007" description="3sat"></configuration>
+		<configuration lcn="209" channelnumber="28724" description="arte"></configuration>
+		<configuration lcn="210" channelnumber="28008" description="KiKA"></configuration>
+		<configuration lcn="211" channelnumber="12040" description="SUPER RTL"></configuration>
+		<configuration lcn="212" channelnumber="1793" description="Disney Channel"></configuration>
+		<configuration lcn="216" channelnumber="28722" description="ONE"></configuration>
+		<configuration lcn="217" channelnumber="28014" description="zdf_neo"></configuration>
+		<configuration lcn="218" channelnumber="12020" description="RTL2"></configuration>
+		<configuration lcn="220" channelnumber="51" description="TELE 5"></configuration>
+		<configuration lcn="221" channelnumber="12061" description="RTLNITRO"></configuration>
+		<configuration lcn="222" channelnumber="17505" description="Pro7 MAXX"></configuration>
+		<configuration lcn="223" channelnumber="17504" description="SAT.1 Gold"></configuration>
+		<configuration lcn="224" channelnumber="776" description="SIXX"></configuration>
+		<configuration lcn="225" channelnumber="35" description="Zee One"></configuration>
+		<configuration lcn="229" channelnumber="772" description="TLC"></configuration>
+		<configuration lcn="230" channelnumber="13110" description="ServusTV Deutschland"></configuration>
+		<configuration lcn="232" channelnumber="63" description="DMAX"></configuration>
+		<configuration lcn="233" channelnumber="28011" description="ZDFinfo"></configuration>
+		<configuration lcn="234" channelnumber="28725" description="PHOENIX"></configuration>
+		<configuration lcn="239" channelnumber="28721" description="tagesschau24"></configuration>
+		<configuration lcn="240" channelnumber="17503" description="N24"></configuration>
+		<configuration lcn="241" channelnumber="12090" description="n-tv"></configuration>
+		<configuration lcn="245" channelnumber="900" description="SPORT1"></configuration>
+		<configuration lcn="247" channelnumber="65" description="DELUXE MUSIC"></configuration>
+		<configuration lcn="257" channelnumber="28110" description="BR Fernsehen Nord"></configuration>
+		<configuration lcn="258" channelnumber="28107" description="BR Fernsehen Süd"></configuration>
+		<configuration lcn="259" channelnumber="28108" description="hr-fernsehen"></configuration>
+		<configuration lcn="260" channelnumber="28228" description="MDR Sachsen"></configuration>
+		<configuration lcn="261" channelnumber="28229" description="MDR S-Anhalt"></configuration>
+		<configuration lcn="262" channelnumber="28230" description="MDR Thüringen"></configuration>
+		<configuration lcn="263" channelnumber="28225" description="NDR FS HH"></configuration>
+		<configuration lcn="264" channelnumber="28224" description="NDR FS MV"></configuration>
+		<configuration lcn="265" channelnumber="28226" description="NDR FS NDS"></configuration>
+		<configuration lcn="266" channelnumber="28227" description="NDR FS SH"></configuration>
+		<configuration lcn="268" channelnumber="28206" description="rbb Berlin"></configuration>
+		<configuration lcn="269" channelnumber="28205" description="rbb Brandenburg"></configuration>
+		<configuration lcn="270" channelnumber="28486" description="SR Fernsehen"></configuration>
+		<configuration lcn="271" channelnumber="28113" description="SWR Fernsehen BW"></configuration>
+		<configuration lcn="272" channelnumber="28231" description="SWR Fernsehen RP"></configuration>
+		<configuration lcn="273" channelnumber="28111" description="WDR Köln"></configuration>
+		<configuration lcn="274" channelnumber="28534" description="WDR Aachen"></configuration>
+		<configuration lcn="275" channelnumber="28306" description="WDR Bielefeld"></configuration>
+		<configuration lcn="276" channelnumber="28536" description="WDR Bonn"></configuration>
+		<configuration lcn="277" channelnumber="28307" description="WDR Dortmund"></configuration>
+		<configuration lcn="278" channelnumber="28308" description="WDR Düsseldorf"></configuration>
+		<configuration lcn="279" channelnumber="28537" description="WDR Duisburg"></configuration>
+		<configuration lcn="280" channelnumber="28309" description="WDR Essen"></configuration>
+		<configuration lcn="281" channelnumber="28310" description="WDR Münster"></configuration>
+		<configuration lcn="282" channelnumber="28311" description="WDR Siegen"></configuration>
+		<configuration lcn="283" channelnumber="28535" description="WDR Wuppertal"></configuration>
+		<configuration lcn="305" channelnumber="662" description="1-2-3.tv"></configuration>
+		<configuration lcn="307" channelnumber="40" description="HSE24"></configuration>
+		<configuration lcn="309" channelnumber="12616" description="Juwelo TV"></configuration>
+		<configuration lcn="310" channelnumber="46" description="mediasparTV Homeshopping"></configuration>
+		<configuration lcn="311" channelnumber="765" description="pearl.tv Shop"></configuration>
+		<configuration lcn="312" channelnumber="1794" description="QVC"></configuration>
+		<configuration lcn="313" channelnumber="64" description="QVC BEAUTY+STYLE"></configuration>
+		<configuration lcn="315" channelnumber="32" description="Sonnenklar TV"></configuration>
 	</lcnlist>
 </custom>

--- a/AutoBouquetsMaker/custom/hd_sat_0192_hd+_CustomradioLCN.xml
+++ b/AutoBouquetsMaker/custom/hd_sat_0192_hd+_CustomradioLCN.xml
@@ -1,0 +1,72 @@
+<custom>
+	<include>yes</include>
+	<lcnlist>
+		<configuration lcn="1" channelnumber="28013" description="DLF"></configuration>
+		<configuration lcn="2" channelnumber="28012" description="DKULTUR"></configuration>
+		<configuration lcn="3" channelnumber="28017" description="DRadio Wissen"></configuration>
+		<configuration lcn="4" channelnumber="28015" description="DRadio DokDeb"></configuration>
+		<configuration lcn="5" channelnumber="28400" description="Bayern 1"></configuration>
+		<configuration lcn="6" channelnumber="28401" description="Bayern 2"></configuration>
+		<configuration lcn="7" channelnumber="28402" description="BAYERN 3"></configuration>
+		<configuration lcn="8" channelnumber="28403" description="BR-KLASSIK"></configuration>
+		<configuration lcn="9" channelnumber="28404" description="B5 aktuell"></configuration>
+		<configuration lcn="10" channelnumber="28405" description="BAYERN plus"></configuration>
+		<configuration lcn="11" channelnumber="28406" description="PULS"></configuration>
+		<configuration lcn="12" channelnumber="28407" description="BR Heimat"></configuration>
+		<configuration lcn="13" channelnumber="28408" description="B5 plus"></configuration>
+		<configuration lcn="14" channelnumber="28419" description="hr1"></configuration>
+		<configuration lcn="15" channelnumber="28420" description="hr2"></configuration>
+		<configuration lcn="16" channelnumber="28421" description="hr3"></configuration>
+		<configuration lcn="17" channelnumber="28422" description="hr4"></configuration>
+		<configuration lcn="18" channelnumber="28424" description="hr-iNFO"></configuration>
+		<configuration lcn="19" channelnumber="28423" description="YOU FM"></configuration>
+		<configuration lcn="20" channelnumber="28428" description="MDR1 SACHSEN"></configuration>
+		<configuration lcn="21" channelnumber="28429" description="MDR S-ANHALT"></configuration>
+		<configuration lcn="22" channelnumber="28430" description="MDR THRINGEN"></configuration>
+		<configuration lcn="23" channelnumber="28434" description="MDR AKTUELL"></configuration>
+		<configuration lcn="24" channelnumber="28431" description="MDR KULTUR"></configuration>
+		<configuration lcn="25" channelnumber="28435" description="MDR KLASSIK"></configuration>
+		<configuration lcn="26" channelnumber="28432" description="MDR JUMP"></configuration>
+		<configuration lcn="27" channelnumber="28433" description="MDR SPUTNIK"></configuration>
+		<configuration lcn="28" channelnumber="28444" description="NDR 1 Nieders."></configuration>
+		<configuration lcn="29" channelnumber="28443" description="NDR 1 Radio MV"></configuration>
+		<configuration lcn="30" channelnumber="28442" description="NDR1WelleNord"></configuration>
+		<configuration lcn="31" channelnumber="28441" description="NDR 90,3"></configuration>
+		<configuration lcn="32" channelnumber="28437" description="NDR 2"></configuration>
+		<configuration lcn="33" channelnumber="28439" description="NDR Info"></configuration>
+		<configuration lcn="34" channelnumber="28438" description="NDR Kultur"></configuration>
+		<configuration lcn="35" channelnumber="28440" description="N-JOY"></configuration>
+		<configuration lcn="36" channelnumber="28445" description="NDR Info Spez."></configuration>
+		<configuration lcn="37" channelnumber="28446" description="NDR Blue"></configuration>
+		<configuration lcn="38" channelnumber="28447" description="NDR Plus"></configuration>
+		<configuration lcn="39" channelnumber="28448" description="Bremen Eins"></configuration>
+		<configuration lcn="40" channelnumber="28450" description="Bremen Vier"></configuration>
+		<configuration lcn="41" channelnumber="28449" description="Nordwestradio"></configuration>
+		<configuration lcn="42" channelnumber="28454" description="Antenne Brandenburg"></configuration>
+		<configuration lcn="43" channelnumber="28455" description="radioBERLIN 88,8"></configuration>
+		<configuration lcn="44" channelnumber="28456" description="radioeins"></configuration>
+		<configuration lcn="45" channelnumber="28452" description="Inforadio"></configuration>
+		<configuration lcn="46" channelnumber="28453" description="Kulturradio"></configuration>
+		<configuration lcn="47" channelnumber="28457" description="Fritz"></configuration>
+		<configuration lcn="48" channelnumber="28461" description="SR 1 Europawelle"></configuration>
+		<configuration lcn="49" channelnumber="28462" description="SR 2 KulturRadio"></configuration>
+		<configuration lcn="50" channelnumber="28463" description="SR 3 Saarlandwelle"></configuration>
+		<configuration lcn="51" channelnumber="28465" description="SWR1 BW"></configuration>
+		<configuration lcn="52" channelnumber="28466" description="SWR1 RP"></configuration>
+		<configuration lcn="53" channelnumber="28467" description="SWR2"></configuration>
+		<configuration lcn="54" channelnumber="28468" description="SWR3"></configuration>
+		<configuration lcn="55" channelnumber="28469" description="SWR4 BW"></configuration>
+		<configuration lcn="56" channelnumber="28470" description="SWR4 RP"></configuration>
+		<configuration lcn="57" channelnumber="28471" description="DASDING"></configuration>
+		<configuration lcn="58" channelnumber="28472" description="SWR Aktuell"></configuration>
+		<configuration lcn="59" channelnumber="28475" description="1LIVE"></configuration>
+		<configuration lcn="60" channelnumber="28481" description="1LIVE diGGi"></configuration>
+		<configuration lcn="61" channelnumber="28476" description="WDR 2"></configuration>
+		<configuration lcn="62" channelnumber="28477" description="WDR 3"></configuration>
+		<configuration lcn="63" channelnumber="28478" description="WDR 4"></configuration>
+		<configuration lcn="64" channelnumber="28479" description="WDR 5"></configuration>
+		<configuration lcn="65" channelnumber="28480" description="COSMO"></configuration>
+		<configuration lcn="66" channelnumber="28482" description="KIRAKA"></configuration>
+		<configuration lcn="67" channelnumber="28483" description="WDR Event"></configuration>
+	</lcnlist>
+</custom>

--- a/AutoBouquetsMaker/providers/sat_0192_hd+.xml
+++ b/AutoBouquetsMaker/providers/sat_0192_hd+.xml
@@ -1,5 +1,5 @@
 <provider>
-	<name>HD+</name>
+	<name>HD+ (DE)</name>
 	<streamtype>dvbs</streamtype>
 	<protocol>lcn</protocol>
 	<transponder
@@ -15,13 +15,23 @@
 		pilot="2"
 	/>
 	<sections>
-		<section number="1">HD+</section>
+		<section number="1">Vollprogramme</section>
+		<section number="10">Kinder</section>
+		<section number="16">Unterhaltung</section>
+		<section number="29">Doku</section>
+		<section number="41">Nachrichten</section>
+		<section number="45">Sport</section>
+		<section number="47">Musik</section>
+		<section number="57">Regionales</section>
+		<section number="104">Einkaufen</section>
+		<section number="128">Religion</section>
+		<section number="134">Österreich</section>
+		<section number="201">SD-Versionen</section>
 	</sections>
 	<servicehacks>
 <![CDATA[
-# SES 75 (21111) is a test card.
-# Austrian HD services are encrypted and not available through HD+.
-if service["service_id"] == 21111 or service["service_name"][-11:] == " HD Austria" or service["service_name"][-6:] == " HD AT":
+# Skip test service and non-HD+ encrypted services.
+if service["service_name"] == "SES 75" or service["service_name"][-11:] == " HD Austria" or service["service_name"][-6:] == " HD AT":
 	skip = True
 ]]>
 	</servicehacks>

--- a/AutoBouquetsMaker/providers/sat_0192_hd+10.xml
+++ b/AutoBouquetsMaker/providers/sat_0192_hd+10.xml
@@ -20,51 +20,8 @@
 	</sections>
 	<servicehacks>
 <![CDATA[
-blacklist = (
-# SD versions of HD services
-              28006, # ZDF
-              28007, # 3sat
-              28008, # KiKA
-              28011, # ZDFinfo
-              28014, # zdf_neo
-              28106, # Das Erste
-              28107, # BR Fernsehen Süd
-              28108, # hr-fernsehen
-              28110, # BR Fernsehen Nord
-              28111, # WDR Köln
-              28113, # SWR Fernsehen BW
-              28205, # rbb Brandenburg
-              28206, # rbb Berlin
-              28224, # NDR FS MV
-              28225, # NDR FS HH
-              28226, # NDR FS NDS
-              28227, # NDR FS SH
-              28228, # MDR Sachsen
-              28229, # MDR S-Anhalt
-              28230, # MDR Thüringen
-              28231, # SWR Fernsehen RP
-              28306, # WDR Bielefeld
-              28307, # WDR Dortmund
-              28308, # WDR Düsseldorf
-              28309, # WDR Essen
-              28310, # WDR Münster
-              28311, # WDR Siegen
-              28486, # SR Fernsehen
-              28534, # WDR Aachen
-              28535, # WDR Wuppertal
-              28536, # WDR Bonn
-              28537, # WDR Duisburg
-              28721, # tagesschau24
-              28722, # ONE
-              28724, # arte
-              28725, # PHOENIX
-# Test services
-              28221, # ARD-TEST-1
-              28395, # WDR Test A
-              28726, # Test-R
-            )
-
-if service["service_id"] in blacklist:
+# Skip test services.
+if service["service_name"] in ("ARD-TEST-1", "Test-R", "WDR Test A"):
 	skip = True
 ]]>
 	</servicehacks>

--- a/AutoBouquetsMaker/providers/sat_0192_hd+12.xml
+++ b/AutoBouquetsMaker/providers/sat_0192_hd+12.xml
@@ -21,6 +21,7 @@
 	</sections>
 	<servicehacks>
 <![CDATA[
+# Skip encrypted services.
 if service["free_ca"] == 1:
 	skip = True
 ]]>

--- a/AutoBouquetsMaker/providers/sat_0192_hd+13.xml
+++ b/AutoBouquetsMaker/providers/sat_0192_hd+13.xml
@@ -20,36 +20,37 @@
 	</sections>
 	<servicehacks>
 <![CDATA[
+# Skip test services, interactive services, and chat line spam.
 blacklist = (
-              12606, # Lustkanal24 TV
-              12607, # MEDIA BROADCAST - Test 6
-              12612, # GayBoys LIVE
-              12615, # Deutsche Girls 24 TV 
-              12616, # Juwelo TV
-              12618, # Dreamgirls24 TV
-              12619, # Erotiksat24 TV
-              12620, # 123-Damenwahl
-              12621, # MEDIA BROADCAST - Test 3
-              12622, # Maennersache TV
-              12623, # Date Line
-              12624, # Fotohandy
-              12625, # Mobile Sex
-              12626, # SEX-Kontakte
-              12627, # Eros TV
-              12628, # Achtung Sexy TV
-              12629, # Traumfrauen TV
-              12630, # Heiss und Sexy TV
-              12635, # Babestation24
-              12636, # Fundorado TV
-              12639, # EROTIKA TV - NEU!
-              12640, # BunnyClub24
-              12641, # Clipmobile
-              12642, # MEDIA BROADCAST - Test 4
-              12643, # ALT Sendersuchlauf starten!!
-              12644, # multithek (Internet)
+              "123-Damenwahl",
+              "ALT Sendersuchlauf starten!!",
+              "Achtung Sexy TV",
+              "Babestation24",
+              "BunnyClub24",
+              "Clipmobile",
+              "Date Line",
+              "Deutsche Girls 24 TV",
+              "Dreamgirls24 TV",
+              "EROTIKA TV - NEU!",
+              "Eros TV",
+              "Erotiksat24 TV",
+              "Fotohandy",
+              "Fundorado TV",
+              "GayBoys LIVE",
+	      "health.tv",                    # test card
+              "Heiss und Sexy TV",
+              "Lustkanal24 TV",
+              "MEDIA BROADCAST - Test 3",
+              "MEDIA BROADCAST - Test 4",
+              "MEDIA BROADCAST - Test 6",
+              "Maennersache TV",
+              "Mobile Sex",
+              "multithek (Internet)",
+              "SEX-Kontakte",
+              "Traumfrauen TV"
             )
 
-if service["service_id"] in blacklist:
+if service["service_name"] in blacklist:
 	skip = True
 ]]>
 	</servicehacks>

--- a/AutoBouquetsMaker/providers/sat_0192_hd+14.xml
+++ b/AutoBouquetsMaker/providers/sat_0192_hd+14.xml
@@ -21,6 +21,7 @@
 	</sections>
 	<servicehacks>
 <![CDATA[
+# Skip encrypted services.
 if service["free_ca"] == 1:
 	skip = True
 ]]>

--- a/AutoBouquetsMaker/providers/sat_0192_hd+15.xml
+++ b/AutoBouquetsMaker/providers/sat_0192_hd+15.xml
@@ -20,6 +20,7 @@
 	</sections>
 	<servicehacks>
 <![CDATA[
+# Skip encrypted services.
 if service["free_ca"] == 1:
 	skip = True
 ]]>

--- a/AutoBouquetsMaker/providers/sat_0192_hd+16.xml
+++ b/AutoBouquetsMaker/providers/sat_0192_hd+16.xml
@@ -1,29 +1,25 @@
 <provider>
-	<name>HD+ #11</name>
+	<name>HD+ #16</name>
 	<dependent>sat_0192_hd+</dependent>
 	<streamtype>dvbs</streamtype>
 	<protocol>lcn</protocol>
 	<transponder
 		orbital_position="192"
-		frequency="11244000"
-		symbol_rate="22000000"
+		frequency="12187000"
+		symbol_rate="27500000"
 		polarization="0"
-		fec_inner="4"
+		fec_inner="3"
 		inversion="2"
 		system="0"
 		modulation="1"
 		roll_off="0"
 		pilot="2"
-		nit_other_table_id="0x00"
 	/>
 	<sections>
 		<section number="1">HD+</section>
 	</sections>
 	<servicehacks>
 <![CDATA[
-# Skip encrypted services, test services and VoD services.
-if service["free_ca"] == 1 or service["service_name"] in ("ATVsmart", "Service 13231", "Service 13232", "Service 13233"):
-	skip = True
 ]]>
 	</servicehacks>
 </provider>

--- a/AutoBouquetsMaker/providers/sat_0192_hd+17.xml
+++ b/AutoBouquetsMaker/providers/sat_0192_hd+17.xml
@@ -1,11 +1,11 @@
 <provider>
-	<name>HD+ #11</name>
+	<name>HD+ #17</name>
 	<dependent>sat_0192_hd+</dependent>
 	<streamtype>dvbs</streamtype>
 	<protocol>lcn</protocol>
 	<transponder
 		orbital_position="192"
-		frequency="11244000"
+		frequency="12545000"
 		symbol_rate="22000000"
 		polarization="0"
 		fec_inner="4"
@@ -14,15 +14,14 @@
 		modulation="1"
 		roll_off="0"
 		pilot="2"
-		nit_other_table_id="0x00"
 	/>
 	<sections>
 		<section number="1">HD+</section>
 	</sections>
 	<servicehacks>
 <![CDATA[
-# Skip encrypted services, test services and VoD services.
-if service["free_ca"] == 1 or service["service_name"] in ("ATVsmart", "Service 13231", "Service 13232", "Service 13233"):
+# Skip test services.
+if service["service_name"] == ".":
 	skip = True
 ]]>
 	</servicehacks>

--- a/AutoBouquetsMaker/providers/sat_0192_hd+18.xml
+++ b/AutoBouquetsMaker/providers/sat_0192_hd+18.xml
@@ -1,28 +1,27 @@
 <provider>
-	<name>HD+ #11</name>
+	<name>HD+ #18</name>
 	<dependent>sat_0192_hd+</dependent>
 	<streamtype>dvbs</streamtype>
 	<protocol>lcn</protocol>
 	<transponder
 		orbital_position="192"
-		frequency="11244000"
-		symbol_rate="22000000"
+		frequency="12460000"
+		symbol_rate="27500000"
 		polarization="0"
-		fec_inner="4"
+		fec_inner="3"
 		inversion="2"
 		system="0"
 		modulation="1"
 		roll_off="0"
 		pilot="2"
-		nit_other_table_id="0x00"
 	/>
 	<sections>
 		<section number="1">HD+</section>
 	</sections>
 	<servicehacks>
 <![CDATA[
-# Skip encrypted services, test services and VoD services.
-if service["free_ca"] == 1 or service["service_name"] in ("ATVsmart", "Service 13231", "Service 13232", "Service 13233"):
+# Skip test services and Sky services.
+if service["service_name"] == "." or ("provider_name" in service and service["provider_name"] == "SKY"):
 	skip = True
 ]]>
 	</servicehacks>

--- a/AutoBouquetsMaker/providers/sat_0192_hd+19.xml
+++ b/AutoBouquetsMaker/providers/sat_0192_hd+19.xml
@@ -1,11 +1,11 @@
 <provider>
-	<name>HD+ #11</name>
+	<name>HD+ #19</name>
 	<dependent>sat_0192_hd+</dependent>
 	<streamtype>dvbs</streamtype>
 	<protocol>lcn</protocol>
 	<transponder
 		orbital_position="192"
-		frequency="11244000"
+		frequency="12662000"
 		symbol_rate="22000000"
 		polarization="0"
 		fec_inner="4"
@@ -14,15 +14,14 @@
 		modulation="1"
 		roll_off="0"
 		pilot="2"
-		nit_other_table_id="0x00"
 	/>
 	<sections>
 		<section number="1">HD+</section>
 	</sections>
 	<servicehacks>
 <![CDATA[
-# Skip encrypted services, test services and VoD services.
-if service["free_ca"] == 1 or service["service_name"] in ("ATVsmart", "Service 13231", "Service 13232", "Service 13233"):
+# Skip encrypted services, interactive services and chat spam.
+if service["free_ca"] == 1 or service["service_name"] in ("4News", "VISIT-X.tv"):
 	skip = True
 ]]>
 	</servicehacks>

--- a/AutoBouquetsMaker/providers/sat_0192_hd+2.xml
+++ b/AutoBouquetsMaker/providers/sat_0192_hd+2.xml
@@ -20,7 +20,7 @@
 	</sections>
 	<servicehacks>
 <![CDATA[
-# Austrian HD services are encrypted and not available through HD+.
+# Skip non-HD+ encrypted services.
 if service["service_name"][-11:] == " HD Austria":
 	skip = True
 ]]>

--- a/AutoBouquetsMaker/providers/sat_0192_hd+4.xml
+++ b/AutoBouquetsMaker/providers/sat_0192_hd+4.xml
@@ -20,9 +20,8 @@
 	</sections>
 	<servicehacks>
 <![CDATA[
-# 10121 = SES Demo
-# Austrian HD services are encrypted and not available through HD+.
-if service["service_id"] == 10121 or service["service_name"][-11:] == " HD Austria":
+# Skip test service and non-HD+ encrypted services.
+if service["service_name"] == "SES Demo" or service["service_name"][-11:] == " HD Austria":
 	skip = True
 ]]>
 	</servicehacks>

--- a/AutoBouquetsMaker/providers/sat_0192_hd+5.xml
+++ b/AutoBouquetsMaker/providers/sat_0192_hd+5.xml
@@ -21,8 +21,8 @@
 	</sections>
 	<servicehacks>
 <![CDATA[
-# RTL Living (11971) and Austrian HD services are encrypted and not available through HD+.
-if service["service_id"] == 11971 or service["service_name"][-11:] == " HD Austria":
+# Skip non-HD+ encrypted services.
+if service["service_name"] == "RTL Living" or service["service_name"][-11:] == " HD Austria":
 	skip = True
 ]]>
 	</servicehacks>

--- a/AutoBouquetsMaker/providers/sat_0192_hd+6.xml
+++ b/AutoBouquetsMaker/providers/sat_0192_hd+6.xml
@@ -20,7 +20,7 @@
 	</sections>
 	<servicehacks>
 <![CDATA[
-# Austrian HD services are encrypted and not available through HD+.
+# Skip non-HD+ encrypted services.
 if service["service_name"][-11:] == " HD Austria":
 	skip = True
 ]]>

--- a/AutoBouquetsMaker/providers/sat_0192_hd+7.xml
+++ b/AutoBouquetsMaker/providers/sat_0192_hd+7.xml
@@ -20,6 +20,9 @@
 	</sections>
 	<servicehacks>
 <![CDATA[
+# Skip test service.
+if service["service_name"] == "INSIGHT TV HD INT":
+	skip = True
 ]]>
 	</servicehacks>
 </provider>

--- a/AutoBouquetsMaker/providers/sat_0192_hd+8.xml
+++ b/AutoBouquetsMaker/providers/sat_0192_hd+8.xml
@@ -20,7 +20,7 @@
 	</sections>
 	<servicehacks>
 <![CDATA[
-# Austrian HD services are encrypted and not available through HD+.
+# Skip non-HD+ encrypted services.
 if service["service_name"][-11:] == " HD Austria":
 	skip = True
 ]]>

--- a/AutoBouquetsMaker/providers/sat_0192_hd+9.xml
+++ b/AutoBouquetsMaker/providers/sat_0192_hd+9.xml
@@ -20,8 +20,8 @@
 	</sections>
 	<servicehacks>
 <![CDATA[
-# Austrian HD services are encrypted and not available through HD+.
-if service["service_name"][-11:] == " HD Austria" or service["service_name"] == ".":
+# Skip test services and non-HD+ encrypted services.
+if service["service_name"] == "." or service["service_name"][-11:] == " HD Austria":
 	skip = True
 ]]>
 	</servicehacks>


### PR DESCRIPTION
With these additions the HD+ bouquet includes all unencrypted services present in the Deutsche Sender bouquet (sat_192_de_PSB1). Encrypted Austrian services are excluded as they're in the AustriaSat bouquet.