### PR TITLE
Correct indentation error (not_fta = ['Sky Disney HD'] )

### DIFF
--- a/AutoBouquetsMaker/providers/cable_ie_mk2.xml
+++ b/AutoBouquetsMaker/providers/cable_ie_mk2.xml
@@ -101,7 +101,7 @@ rename = {
 	}
 
 #Some encrypted channels are wrongly flagged as FreToAir.
-	not_fta = ['Sky Disney HD']
+not_fta = ['Sky Disney HD']
 
 #List channels to skip
 blacklist = [731, 732, 733, 734, 735, 736, 737, 738, 739, 740, 751,752,753,754,999]


### PR DESCRIPTION
01:04:20.2139 { D }   File "<string>", line 24
01:04:20.2140 { D }     not_fta = ['Sky Disney HD']
01:04:20.2140 { D }     ^
01:04:20.2141 { D } IndentationError: unexpected indent
01:04:20.2142 [ E ] python/python.cpp:209 call (PyObject_CallObject(<bound method AutoBouquetsMaker.doScan of <class 'Plugins.SystemPlugins.AutoBouquetsMaker.scanner.main.AutoBouquetsMaker'>>,()) failed)
]]>