### PR TITLE
Add STV 2 to ITV Regions

### DIFF
--- a/AutoBouquetsMaker/providers/sat_282_sky_uk.xml
+++ b/AutoBouquetsMaker/providers/sat_282_sky_uk.xml
@@ -367,6 +367,7 @@ except:
 		3527: "STV Edinburgh",
 		4012: "UTV Ireland",
 		4055: "STV HD",
+		5070: "STV 2",
 		6000: "ITV London",
 		6010: "ITV Central South",
 		6011: "ITV Central East",


### PR DESCRIPTION
This allows users to add STV 2 to the ITV Regions hack in CustomMix