### PR TITLE
Add ability to specify service type (SoC, gstreamer, exteplayer, etc)…

### DIFF
--- a/AutoBouquetsMaker/src/plugin.py
+++ b/AutoBouquetsMaker/src/plugin.py
@@ -61,6 +61,7 @@ config.autobouquetsmaker.placement = ConfigSelection(default = "top", choices = 
 config.autobouquetsmaker.skipservices = ConfigYesNo(default = True)
 config.autobouquetsmaker.showextraservices = ConfigYesNo(default = False)
 config.autobouquetsmaker.extra_debug = ConfigYesNo(default = False)
+config.autobouquetsmaker.servicetype = ConfigSelection(default = "1", choices = [("1", _("1")), ("4097", _("4097")), ("5001", _("5001")), ("5002", _("5002"))])
 config.autobouquetsmaker.FTA_only = ConfigText("", False)
 
 def main(session, **kwargs):

--- a/AutoBouquetsMaker/src/scanner/bouquetswriter.py
+++ b/AutoBouquetsMaker/src/scanner/bouquetswriter.py
@@ -927,7 +927,8 @@ class BouquetsWriter():
 		print>>log, "[ABM-BouquetsWriter] Done"
 
 	def bouquetServiceLine(self, service):
-		return "#SERVICE 1:0:%x:%x:%x:%x:%x:0:0:0:%s\n%s" % (
+		return "#SERVICE %s:0:%x:%x:%x:%x:%x:0:0:0:%s\n%s" % (
+			(("%s" % config.autobouquetsmaker.servicetype.value) if "stream" in service else "1"),
 			service["service_type"],
 			service["service_id"],
 			service["transport_stream_id"],

--- a/AutoBouquetsMaker/src/setup.py
+++ b/AutoBouquetsMaker/src/setup.py
@@ -526,6 +526,7 @@ class AutoBouquetsMaker_Setup(ConfigListScreen, Screen):
 			self.list.append(getConfigListEntry(_("Skip services on not configured sats"), config.autobouquetsmaker.skipservices, _("If a service is carried on a satellite that is not configured, 'yes' means the channel will not appear in the channel list, 'no' means the channel will show in the channel list but be greyed out and not be accessible.")))
 			self.list.append(getConfigListEntry(_("Include 'not indexed' channels"), config.autobouquetsmaker.showextraservices, _("When a search finds extra channels that do not have an allocated channel number, 'yes' will add these at the end of the channel list, and 'no' means these will not be included.")))
 			self.list.append(getConfigListEntry(_("Extra debug"), config.autobouquetsmaker.extra_debug, _("This feature is for development only. Requires debug logs to be enabled or enigma2 to be started in console mode.")))
+			self.list.append(getConfigListEntry(_("Service Type for IPTV Streams"), config.autobouquetsmaker.servicetype, _("Specifies service type for IPTV streams.  1 use default box streamer, 4097 use Gstreamer/Servicemp3, 5001 use Gstreamer/gst-player and 5002 use exteplayer3. Please ensure you have suitable streamer installed first.")))
 		self.list.append(getConfigListEntry(_("Show in extensions"), config.autobouquetsmaker.extensions, _("When enabled, allows you start a scan from the extensions list.")))
 
 		self["config"].list = self.list


### PR DESCRIPTION
… for IPTV streams

In addition to @Huevos feature of having IPTV streams in place of any
existing (ie dark) channels, this feature allows these streams to use 
another service type other than default streamer (ie use gstreamer, etc).