### PR TITLE
Update cable_uk_virgin.xml

### DIFF
--- a/AutoBouquetsMaker/providers/cable_uk_virgin.xml
+++ b/AutoBouquetsMaker/providers/cable_uk_virgin.xml
@@ -164,7 +164,7 @@ except:
 	provider = "Virgin Media"
 
 	#Channel names have quotes, channel numbers do not. Example: ['ITV HD', 250, 500]
-	blacklist = [295,650,651,743,744,745,746,811,947,'BT Events HD','Channel Moved','Channel Closed','hayu','ITVEvents HD','L Pack Tier 4','M Pack Tier 1','More TV Pack Tier 2','motorsport.tv','M+ Pack Tier 3','Netflix','PIN Protection Help','S4C HD','XL Pack Tier 5','Vevo','Worldbox','YouTube']
+	blacklist = [295,650,651,743,744,745,746,811,947,'BT Events HD','BT Sport Ultimate','BT Sport Ultimate WSL','Channel Moved','Channel Closed','Good Food HD','Good Food','Good Food +1','hayu','ITVEvents HD','L Pack Tier 4','M Pack Tier 1','More TV Pack Tier 2','motorsport.tv','M+ Pack Tier 3','Netflix','New Music On Demand','PIN Protection Help','Prime Video','S4C HD','XL Pack Tier 5','Vevo','Virgin TV Ultra HD','Worldbox','YouTube']
 
 	bt_sports_xtra = ["BT Sport Extra 0","BT Sport Extra 1","BT Sport Extra 2","BT Sport Extra 3","BT Sport Extra 4","BT Sport Extra 5","BT Sport Extra 6"]
 


### PR DESCRIPTION
Remove more dead channels.
Is there any reason we keep the "on demand" or store/preview virgin specific channels ? I would happily remove those as well.