### PR TITLE
Adds ability to specify serviceref type

### DIFF
--- a/AutoBouquetsMaker/custom/README.txt
+++ b/AutoBouquetsMaker/custom/README.txt
@@ -307,6 +307,23 @@ The name and service reference will be the same as the DVB service. This will al
 	</streams>
 </custommix>
 
+
+You can also give your stream a "service reference type". This allows you to tell the receiver which playback software to use for that individual stream.
+
+In this example "servicereftype" has been added:
+
+<custommix>
+	<streams>
+		<stream url="http://stream.source:port/live/username/F36/password/308.ts" target="118" servicereftype="4097" />
+	</streams>
+</custommix>
+
+The following is a list of currently valid "service reference types":
+	1		processed by the SoC (for when buffering is not required)
+	4097	processed by gstreamer via servicemp3
+	5001	processed by gstreamer via gst-player
+	5002	processed via extplayer3
+
 You can also add streams into empty LCN slots. As these do not have a name from the DVB source, it has to be specified.
 When inserting streams into empty LCN slots, the service reference will be "1:0:1:0:0:0:0:0:0:0:".
 EPG will not work becuase of this.

--- a/AutoBouquetsMaker/src/scanner/bouquetswriter.py
+++ b/AutoBouquetsMaker/src/scanner/bouquetswriter.py
@@ -352,7 +352,7 @@ class BouquetsWriter():
 			bouquets = open(path + "/" + filename, "r")
 			content = bouquets.read().strip().split("\n")
 			bouquets.close()
-			recognised_service_lines = ["#SERVICE %d:0:" % i for i in (1,4097,5001,5002)] + ["#SERVICE 1:7:"]
+			recognised_service_lines = ["#SERVICE %d:0:" % i for i in Tools.SERVICEREF_ALLOWED_TYPES] + ["#SERVICE 1:7:"]
 			for line in content:
 				if "%s:" % ':'.join(line.split(":")[:2]) in recognised_service_lines: # service or iptv line found, eg "#SERVICE 4097:0:"
 					return True
@@ -891,7 +891,8 @@ class BouquetsWriter():
 		print>>log, "[ABM-BouquetsWriter] Done"
 
 	def bouquetServiceLine(self, service):
-		return "#SERVICE 1:0:%x:%x:%x:%x:%x:0:0:0:%s\n%s" % (
+		return "#SERVICE %d:0:%x:%x:%x:%x:%x:0:0:0:%s\n%s" % (
+			(service["servicereftype"] if "servicereftype" in service and service["servicereftype"] in Tools.SERVICEREF_ALLOWED_TYPES else 1),
 			service["service_type"],
 			service["service_id"],
 			service["transport_stream_id"],

--- a/AutoBouquetsMaker/src/scanner/tools.py
+++ b/AutoBouquetsMaker/src/scanner/tools.py
@@ -6,6 +6,7 @@ from dvbscanner import DvbScanner
 from urllib import quote
 
 class Tools():
+	SERVICEREF_ALLOWED_TYPES = [1, 4097, 5001, 5002]
 	def parseXML(self, filename):
 		try:
 			tool = open(filename, "r")
@@ -173,6 +174,7 @@ class Tools():
 							url = ''
 							target = ''
 							name = ''
+							servicereftype = ''
 							for i in range(0, node2.attributes.length):
 								if node2.attributes.item(i).name == "name":
 									name = node2.attributes.item(i).value.encode("utf-8")
@@ -182,11 +184,14 @@ class Tools():
 										url = quote(url) # single encode url
 								elif node2.attributes.item(i).name == "target":
 									target = int(node2.attributes.item(i).value)
+								elif node2.attributes.item(i).name == "servicereftype":
+									servicereftype = int(node2.attributes.item(i).value)
 							if url and target and target in customised["video"]: # must be a current service
 								customised["video"][target]["stream"] = url
 							elif name and url and target and target not in customised["video"]: # non existing service
 								customised["video"][target] = {'service_id': 0, 'transport_stream_id': 0, 'original_network_id': 0, 'namespace': 0, 'service_name': name, 'number': target, 'numbers': [target], 'free_ca': 0, 'service_type': 1, 'stream': url}
-
+							if servicereftype and servicereftype in self.SERVICEREF_ALLOWED_TYPES and target and target in customised["video"] and "stream" in customised["video"][target]: # if a stream was added above, a custom servicereftype may also be added
+								customised["video"][target]["servicereftype"] = servicereftype
 				elif node.tagName == "deletes":
 					for node2 in node.childNodes:
 						if node2.nodeType == node2.ELEMENT_NODE and node2.tagName == "delete":


### PR DESCRIPTION
Adds ability to specify service ref types (ie 4097, 5001, etc) on a case-by-case basis for each stream added via custom mix file

All credit goes to @Huevos

This was discussed in below thread:
https://www.world-of-satellite.com/showthread.php?58583-ABM-with-use-of-IPTV-Streams&p=491606&viewfull=1#post491606