### PR TITLE
Adding PT MEO,NOS (Hispasat 30W), TDT (terrestrial)

### DIFF
--- a/AutoBouquetsMaker/providers/sat_3300_pt_meo.xml
+++ b/AutoBouquetsMaker/providers/sat_3300_pt_meo.xml
@@ -1,0 +1,26 @@
+<provider>
+	<name>MEO</name>
+	<streamtype>dvbs</streamtype>
+	<protocol>lcn</protocol>
+	<transponder
+		orbital_position="3300"
+		frequency="12130000"
+		symbol_rate="27500000"
+		polarization="0"
+		fec_inner="3"
+		inversion="2"
+		system="1"
+		modulation="2"
+		roll_off="0"
+		pilot="2"
+		tsid="101"
+		onid="83"
+	/>
+	<sections>
+		<section number="1">MEO</section>
+	</sections>
+	<servicehacks>
+<![CDATA[
+]]>
+	</servicehacks>
+</provider>

--- a/AutoBouquetsMaker/providers/sat_3300_pt_nos.xml
+++ b/AutoBouquetsMaker/providers/sat_3300_pt_nos.xml
@@ -1,0 +1,26 @@
+<provider>
+	<name>NOS</name>
+	<streamtype>dvbs</streamtype>
+	<protocol>lcn</protocol>
+	<transponder
+		orbital_position="3300"
+		frequency="12360000"
+		symbol_rate="27500000"
+		polarization="0"
+		fec_inner="3"
+		inversion="2"
+		system="1"
+		modulation="2"
+		roll_off="0"
+		pilot="2"
+		tsid="38"
+		onid="54"
+	/>
+	<sections>
+		<section number="1">NOS</section>
+	</sections>
+	<servicehacks>
+<![CDATA[
+]]>
+	</servicehacks>
+</provider>

--- a/AutoBouquetsMaker/providers/terrestrial_pt_tdt.xml
+++ b/AutoBouquetsMaker/providers/terrestrial_pt_tdt.xml
@@ -1,0 +1,40 @@
+<provider>
+	<name>TDT</name>
+	<streamtype>dvbt</streamtype>
+	<protocol>lcn</protocol>
+	<dvbtconfigs>
+		<configuration key="nisa_47" frequency="682000000">Nisa (47)</configuration>
+		<configuration key="canal_30" frequency="546000000">Canal 30</configuration>
+		<configuration key="canal_33" frequency="570000000">Canal 33</configuration>
+		<configuration key="canal_34" frequency="578000000">Canal 34</configuration>
+		<configuration key="canal_35" frequency="586000000">Canal 35</configuration>
+		<configuration key="canal_36" frequency="594000000">Canal 36</configuration>
+		<configuration key="canal_37" frequency="602000000">Canal 37</configuration>
+		<configuration key="canal_40" frequency="626000000">Canal 40</configuration>
+		<configuration key="canal_41" frequency="634000000">Canal 41</configuration>
+		<configuration key="canal_42" frequency="642000000">Canal 42</configuration>
+		<configuration key="canal_43" frequency="650000000">Canal 43</configuration>
+		<configuration key="canal_44" frequency="658000000">Canal 44</configuration>
+		<configuration key="canal_45" frequency="666000000">Canal 45</configuration>
+		<configuration key="canal_46" frequency="674000000">Canal 46</configuration>
+		<configuration key="canal_47" frequency="682000000">Canal 47</configuration>
+		<configuration key="canal_48" frequency="690000000">Canal 48</configuration>
+		<configuration key="canal_56" frequency="754000000">Canal 56 (leg.)</configuration>
+	</dvbtconfigs>
+
+	<!-- Custom transponders are ONLY needed for HD muxes and for areas where tuning issues occur after running ABM -->
+	<customtransponders>
+	</customtransponders>
+
+	<sections>
+		<section number="1">TDT</section>
+	</sections>
+
+	<swapchannels>
+	</swapchannels>
+
+	<servicehacks>
+	<![CDATA[
+	]]>
+	</servicehacks>
+</provider>


### PR DESCRIPTION
First stab at adding Portuguese providers MEO & NOS on Hispasat 30.0W, as well as Portuguese terrestrial television provider file.

No real sections (categories), blacklists, channel ordering/swaps, or service hacks. 