### PR TITLE
Adding Pantelio on 30W

### DIFF
--- a/AutoBouquetsMaker/providers/sat_3300_sk_pantelio.xml
+++ b/AutoBouquetsMaker/providers/sat_3300_sk_pantelio.xml
@@ -1,0 +1,31 @@
+<provider>
+	<name>Pantelio</name>
+	<streamtype>dvbs</streamtype>
+	<protocol>lcn</protocol>
+	<transponder
+		orbital_position="3300"
+		frequency="11731000"
+		symbol_rate="30000000"
+		polarization="1"
+		fec_inner="3"
+		inversion="2"
+		system="1"
+		modulation="2"
+		roll_off="0"
+		pilot="2"
+		tsid="306"
+		onid="5677"
+	/>
+	<sections>
+		<section number="1">Pantelio</section>
+	</sections>
+	<servicehacks>
+<![CDATA[
+blacklist = (
+            )
+
+if service["service_name"] in blacklist or "Test" in service["service_name"]:
+	skip = True
+]]>
+	</servicehacks>
+</provider>


### PR DESCRIPTION
Adding Pantelio package.

Setting FEC to 3/4 as reported on a couple of frequency sites as well as experimentally verified, instead of 5/6 as indicated on pantelio.tv.