### PR TITLE
Update sat_282_sky_uk.xml

### DIFF
--- a/AutoBouquetsMaker/providers/sat_282_sky_uk.xml
+++ b/AutoBouquetsMaker/providers/sat_282_sky_uk.xml
@@ -480,7 +480,6 @@ except:
 		5036, # AMC from BT
 		1024, # 10002
 		1027, # 10001
-		2320, # Dave ja vu
 	]
 
 #Some channels are FTA, but they incorrectly have Encrypted flag.


### PR DESCRIPTION
Dave Ja Vu seems to be FTA on Astra 2 now.