### PR TITLE
Revert "handle some python 3 issues"

### DIFF
--- a/AutoBouquetsMaker/src/scanner/dvbscanner.py
+++ b/AutoBouquetsMaker/src/scanner/dvbscanner.py
@@ -253,7 +253,7 @@ class DvbScanner():
 					print("[ABM-DvbScanner] raw section above is from NIT other table.")
 				network_id = section["header"]["network_id"]
 
-				if network_id in nit_other_section_version and nit_other_section_version[network_id] == section["header"]["version_number"] and all(completed == True for completed in itervalues(nit_other_completed)):
+				if network_id in nit_other_section_version and nit_other_section_version[network_id] == section["header"]["version_number"] and all(completed == True for completed in nit_other_completed.itervalues()):
 					all_nit_others_completed = True
 				else:
 

--- a/genmetaindex.py
+++ b/genmetaindex.py
@@ -3,25 +3,24 @@ import sys, os
 from xml.etree.ElementTree import ElementTree, Element
 
 root = Element("index")
-encoding = ("unicode" if sys.version_info[0] >= 3 else "utf-8")
 
 for file in sys.argv[1:]:
 	p = ElementTree()
 	p.parse(file)
-
+	
 	package = Element("package")
 	package.set("details", os.path.basename(file))
-
+	
 	# we need all prerequisites
 	package.append(p.find("prerequisites"))
-
+	
 	info = None
 	# we need some of the info, but not all
 	for i in p.findall("info"):
 		if not info:
 			info = i
 	assert info
-
+	
 	for i in info[:]:
 		if i.tag not in ["name", "packagename", "packagetype", "shortdescription"]:
 			info.remove(i)
@@ -48,4 +47,4 @@ def indent(elem, level=0):
 
 indent(root)
 
-ElementTree(root).write(sys.stdout, encoding=encoding)
+ElementTree(root).write(sys.stdout)

--- a/xml2po.py
+++ b/xml2po.py
@@ -1,25 +1,18 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
 from __future__ import print_function
-try:
-    import builtins
-except ImportError:
-    import __builtin__ as builtins
-
 import sys
 import os
+import string
+
 import re
 from xml.sax import make_parser
 from xml.sax.handler import ContentHandler, property_lexical_handler
-
 try:
 	from _xmlplus.sax.saxlib import LexicalHandler
 	no_comments = False
 except ImportError:
 	class LexicalHandler:
-		def __init__(self):
-			pass
-
+		pass
 	no_comments = True
 
 class parseXML(ContentHandler, LexicalHandler):
@@ -30,15 +23,15 @@ class parseXML(ContentHandler, LexicalHandler):
 		self.ishex = re.compile('#[0-9a-fA-F]+\Z')
 
 	def comment(self, comment):
-		if "TRANSLATORS:" in comment:
+		if comment.find("TRANSLATORS:") != -1:
 			self.last_comment = comment
 
 	def startElement(self, name, attrs):
-		for x in ["text", "title", "value", "caption", "summary", "description"]:
+		for x in ["text", "title", "value", "caption", "summary"]:
 			try:
-				k = builtins.str(attrs[x])
+				k = str(attrs[x])
 				if k.strip() != "" and not self.ishex.match(k):
-					attrlist.add((k, self.last_comment))
+					attrlist.add((attrs[x], self.last_comment))
 					self.last_comment = None
 			except KeyError:
 				pass
@@ -55,7 +48,7 @@ if not no_comments:
 for arg in sys.argv[1:]:
 	if os.path.isdir(arg):
 		for file in os.listdir(arg):
-			if file.endswith(".xml"):
+			if (file.endswith(".xml")):
 				parser.parse(os.path.join(arg, file))
 	else:
 		parser.parse(arg)
@@ -66,11 +59,11 @@ for arg in sys.argv[1:]:
 	for (k, c) in attrlist:
 		print()
 		print('#: ' + arg)
-		k.replace("\\n", "\"\n\"")
+		string.replace(k, "\\n", "\"\n\"")
 		if c:
 			for l in c.split('\n'):
 				print("#. ", l)
-		print('msgid "' + builtins.str(k) + '"')
+		print('msgid "' + str(k) + '"')
 		print('msgstr ""')
 
 	attrlist = set()


### PR DESCRIPTION
Reverts oe-alliance/AutoBouquetsMaker#166

```
23:17:29.3505 {   } /usr/lib/python2.7/site-packages/twisted/python/util.py:815 untilConcludes 2020-11-29 23:17:29+0100 [-] Traceback (most recent call last):
23:17:29.3510 {   } /usr/lib/python2.7/site-packages/twisted/python/util.py:815 untilConcludes 2020-11-29 23:17:29+0100 [-]   File "/usr/lib/enigma2/python/Plugins/SystemPlugins/AutoBouquetsMaker/scanner/main.py", line 486, in doScan
23:17:29.3516 {   } /usr/lib/python2.7/site-packages/twisted/python/util.py:815 untilConcludes 2020-11-29 23:17:29+0100 [-]   File "/usr/lib/enigma2/python/Plugins/SystemPlugins/AutoBouquetsMaker/scanner/manager.py", line 223, in read
23:17:29.3522 {   } /usr/lib/python2.7/site-packages/twisted/python/util.py:815 untilConcludes 2020-11-29 23:17:29+0100 [-]   File "/usr/lib/enigma2/python/Plugins/SystemPlugins/AutoBouquetsMaker/scanner/dvbscanner.py", line 256, in updateTransponders
23:17:29.3529 { E } /usr/lib/python2.7/site-packages/twisted/python/util.py:815 untilConcludes 2020-11-29 23:17:29+0100 [-] NameError: global name 'itervalues' is not defined
23:17:29.3530 [ E ] python/python.cpp:210 call [ePyObject] (PyObject_CallObject(<bound method AutoBouquetsMaker.doScan of <class 'Plugins.SystemPlugins.AutoBouquetsMaker.scanner.main.AutoBouquetsMaker'>>,()) failed)
```

I've already commented on an issue with the "dvbscanner.py" file that is affected. Please read this my comment:

https://github.com/oe-alliance/AutoBouquetsMaker/commit/e5babb95d8fc9be30334e0820ca55c9826c2b2f4#diff-8f207dd4349012263f0add852eeeb86b230d76dcfa4b95e7a7300a2cf791d298
