### PR TITLE
[Sky UK 28.2] Add "London Live" at 173 when it's free

### DIFF
--- a/AutoBouquetsMaker/providers/sat_130_sky_italy.xml
+++ b/AutoBouquetsMaker/providers/sat_130_sky_italy.xml
@@ -42,13 +42,13 @@
 # example: "ITV 2": 118,
 #
 ########################################################################
-channels_to_add = {
+channels_to_add_by_name = {
 	
 }
-if service["service_name"] in channels_to_add and service["service_type"] in DvbScanner.VIDEO_ALLOWED_TYPES and channels_to_add[service["service_name"]] not in LCNs_in_use:
-	LCNs_in_use.append(channels_to_add[service["service_name"]])
-	service["number"] = channels_to_add[service["service_name"]]
-	service["numbers"] = [channels_to_add[service["service_name"]]]
+if service["service_name"] in channels_to_add_by_name and service["service_type"] in DvbScanner.VIDEO_ALLOWED_TYPES and channels_to_add_by_name[service["service_name"]] not in LCNs_in_use:
+	LCNs_in_use.append(channels_to_add_by_name[service["service_name"]])
+	service["number"] = channels_to_add_by_name[service["service_name"]]
+	service["numbers"] = [channels_to_add_by_name[service["service_name"]]]
 # end: slot some extra channels into vacant slots in the provider list
 
 if service["number"] >= 1000 and service["number"] <= 1450: # not indexed channels

--- a/AutoBouquetsMaker/providers/sat_282_sky_irl.xml
+++ b/AutoBouquetsMaker/providers/sat_282_sky_irl.xml
@@ -155,7 +155,7 @@ except:
 	#
 	########################################################################
 
-	channels_to_add = {
+	channels_to_add_by_name = {
 		"London Live": 117 #This is only added if you do not have an official local 117 service
 	}
 
@@ -391,10 +391,10 @@ if custom and service["service_type"] != 2 and service["transport_stream_id"] in
 	skip.skip = True
 
 # Add channels by name
-if custom and service["service_name"] in channels_to_add and service["service_type"] in DvbScanner.VIDEO_ALLOWED_TYPES and channels_to_add[service["service_name"]] not in LCNs_in_use:
-	LCNs_in_use.append(channels_to_add[service["service_name"]])
-	service["number"] = channels_to_add[service["service_name"]]
-	service["numbers"] = [channels_to_add[service["service_name"]]]
+if custom and service["service_name"] in channels_to_add_by_name and service["service_type"] in DvbScanner.VIDEO_ALLOWED_TYPES and channels_to_add_by_name[service["service_name"]] not in LCNs_in_use:
+	LCNs_in_use.append(channels_to_add_by_name[service["service_name"]])
+	service["number"] = channels_to_add_by_name[service["service_name"]]
+	service["numbers"] = [channels_to_add_by_name[service["service_name"]]]
 
 # Add channels by ID
 if custom and service["channel_id"] in channels_to_add_by_id and service["service_type"] in DvbScanner.VIDEO_ALLOWED_TYPES and channels_to_add_by_id[service["channel_id"]] not in LCNs_in_use:

--- a/AutoBouquetsMaker/providers/sat_282_sky_uk.xml
+++ b/AutoBouquetsMaker/providers/sat_282_sky_uk.xml
@@ -352,7 +352,7 @@ except:
 	########################################################################
 
 	channels_to_add = {
-		"London Live": 117 #This is only added if you do not have an official local 117 service
+		"London Live": 173 #This will add London Live at 173 when it's free, which is currently everywhere except London. In London Sky puts London Live at 117 and BBC Three at 173.
 	}
 
 	channels_to_add_by_id = {

--- a/AutoBouquetsMaker/providers/sat_282_sky_uk.xml
+++ b/AutoBouquetsMaker/providers/sat_282_sky_uk.xml
@@ -351,7 +351,7 @@ except:
 	#
 	########################################################################
 
-	channels_to_add = {
+	channels_to_add_by_name = {
 		"London Live": 173 #This will add London Live at 173 when it's free, which is currently everywhere except London. In London Sky puts London Live at 117 and BBC Three at 173.
 	}
 
@@ -539,10 +539,10 @@ if custom and service["service_type"] != 2 and service["transport_stream_id"] in
 	skip.skip = True
 
 # Add channels by name
-if custom and service["service_name"] in channels_to_add and service["service_type"] in DvbScanner.VIDEO_ALLOWED_TYPES and channels_to_add[service["service_name"]] not in LCNs_in_use:
-	LCNs_in_use.append(channels_to_add[service["service_name"]])
-	service["number"] = channels_to_add[service["service_name"]]
-	service["numbers"] = [channels_to_add[service["service_name"]]]
+if custom and service["service_name"] in channels_to_add_by_name and service["service_type"] in DvbScanner.VIDEO_ALLOWED_TYPES and channels_to_add_by_name[service["service_name"]] not in LCNs_in_use:
+	LCNs_in_use.append(channels_to_add_by_name[service["service_name"]])
+	service["number"] = channels_to_add_by_name[service["service_name"]]
+	service["numbers"] = [channels_to_add_by_name[service["service_name"]]]
 
 # Add channels by ID
 if custom and service["channel_id"] in channels_to_add_by_id and service["service_type"] in DvbScanner.VIDEO_ALLOWED_TYPES and channels_to_add_by_id[service["channel_id"]] not in LCNs_in_use:


### PR DESCRIPTION
This will add London Live at 173 when it's free, which is currently everywhere except London. In London Sky puts London Live at 117 and BBC Three at 173.