### PR TITLE
[Sky 28.2] Remove name added for 53595 because it has a real name now that is different!

### DIFF
--- a/AutoBouquetsMaker/providers/sat_282_sky_irl.xml
+++ b/AutoBouquetsMaker/providers/sat_282_sky_irl.xml
@@ -299,7 +299,6 @@ except:
 		53710: "NBC News NOW HD",
 		22305: "QVC HD",
 		22306: "QVC Style HD",
-		53595: "The Craft Store HD",
 	} 
 
 	whitelist = ['ITV HD',752,]

--- a/AutoBouquetsMaker/providers/sat_282_sky_uk.xml
+++ b/AutoBouquetsMaker/providers/sat_282_sky_uk.xml
@@ -447,7 +447,6 @@ except:
 		53710: "NBC News NOW HD",
 		22305: "QVC HD",
 		22306: "QVC Style HD",
-		53595: "The Craft Store HD",
 	} 
 
 	whitelist = ['ITV HD',752,]


### PR DESCRIPTION
The name I gave 53595 "The Craft Store HD" does not match the name it got when it was given a real name.
Though as far as I can see, my name actually shows what it is (it seems to be an HD version of "The Craft Store").
But, at least until I'm sure what they're up to, I suggest we remove the name I gave it for now.