### PR TITLE
[Sky 28.2] Remove names for testing channels that have gone live on Sky UK.

### DIFF
--- a/AutoBouquetsMaker/providers/sat_282_sky_irl.xml
+++ b/AutoBouquetsMaker/providers/sat_282_sky_irl.xml
@@ -297,8 +297,6 @@ except:
 
 	rename_by_sid = {
 		53710: "NBC News NOW HD",
-		22305: "QVC HD",
-		22306: "QVC Style HD",
 	} 
 
 	whitelist = ['ITV HD',752,]

--- a/AutoBouquetsMaker/providers/sat_282_sky_uk.xml
+++ b/AutoBouquetsMaker/providers/sat_282_sky_uk.xml
@@ -445,8 +445,6 @@ except:
 
 	rename_by_sid = {
 		53710: "NBC News NOW HD",
-		22305: "QVC HD",
-		22306: "QVC Style HD",
 	} 
 
 	whitelist = ['ITV HD',752,]


### PR DESCRIPTION
Remove names I added for "QVC HD" and "QVC Style HD" while they were testing.
They have now gone live on Sky UK.

I don't know for sure what state "NBC News NOW HD" is in because I don't have a Sky subscription and it's encrypted.
But I suspect that name is now redundant too.