### PR TITLE
Don't exclude NOS and MEO adult channel, use parental control

### DIFF
--- a/AutoBouquetsMaker/providers/sat_3300_pt_meo.xml
+++ b/AutoBouquetsMaker/providers/sat_3300_pt_meo.xml
@@ -22,9 +22,6 @@
 	<servicehacks>
 <![CDATA[
 blacklist = (
-			"Playboy TV",
-			"Venus",
-			"HOT",
 			"MEO"
             )
 

--- a/AutoBouquetsMaker/providers/sat_3300_pt_nos.xml
+++ b/AutoBouquetsMaker/providers/sat_3300_pt_nos.xml
@@ -22,8 +22,6 @@
 	<servicehacks>
 <![CDATA[
 blacklist = (
-			"Playboy TV",
-			"Hot",
 			"SW Kaon DTH",
 			"NG_Zapper_Intek",
 			"NG_Zapper_5.14",


### PR DESCRIPTION
Instead of excluding adult channel, use parental control to block adult channels.