### PR TITLE
Fix DVB-T frequency when 1 transponder found at the NIT table and that frequency is different from tune frequency.

### DIFF
--- a/AutoBouquetsMaker/src/scanner/dvbscanner.py
+++ b/AutoBouquetsMaker/src/scanner/dvbscanner.py
@@ -412,7 +412,7 @@ class DvbScanner():
 				print("[ABM-DvbScanner] transponder", transponder)
 
 		# Fix DVB-T frequency when 1 transponder found at the NIT table and the frequency is different from tune frequency
-		if transponders_count == 1 and tune_freq > 0 and transponders[transponder_key]["frequency"] != tune_freq:
+		if transponders_count == 1 and len(customtransponder) == 0 and tune_freq > 0 and transponders[transponder_key]["frequency"] != tune_freq:
 			print("[ABM-DvbScanner] Fix transponder frequency from NIT frequency %d to %d" % (transponders[transponder_key]["frequency"], tune_freq), file=log)
 			transponders[transponder_key]["frequency"] = tune_freq
 

--- a/AutoBouquetsMaker/src/scanner/dvbscanner.py
+++ b/AutoBouquetsMaker/src/scanner/dvbscanner.py
@@ -411,7 +411,7 @@ class DvbScanner():
 			if self.extra_debug:
 				print("[ABM-DvbScanner] transponder", transponder)
 
-		# Fix DVB-T frequency when 1 transponder found and the frequency is different from tune frequency
+		# Fix DVB-T frequency when 1 transponder found at the NIT table and the frequency is different from tune frequency
 		if transponders_count == 1 and tune_freq > 0 and transponders[transponder_key]["frequency"] != tune_freq:
 			print("[ABM-DvbScanner] Fix transponder frequency from NIT frequency %d to %d" % (transponders[transponder_key]["frequency"], tune_freq), file=log)
 			transponders[transponder_key]["frequency"] = tune_freq

--- a/AutoBouquetsMaker/src/scanner/manager.py
+++ b/AutoBouquetsMaker/src/scanner/manager.py
@@ -219,6 +219,9 @@ class Manager():
 					if providers[provider_key]["streamtype"] == 'dvbc':
 						bouquet = providers[provider_key]["bouquets"][bouquet_key]
 						tmp = scanner.updateTransponders(self.transponders, True, customtransponders, bouquet["netid"], bouquet["bouquettype"])
+					elif providers[provider_key]["streamtype"] == 'dvbt':
+						tune_freq = providers[provider_key]["bouquets"][bouquet_key]["frequency"]
+						tmp = scanner.updateTransponders(self.transponders, True, customtransponders, bouquet_id=bouquet_id, tune_freq=tune_freq)
 					else:
 						tmp = scanner.updateTransponders(self.transponders, True, customtransponders, bouquet_id=bouquet_id)
 					if providers[provider_key]["protocol"] in ("lcnbat", "lcnbat2"):


### PR DESCRIPTION
Fix DVB-T frequency when 1 transponder found at the NIT table and that frequency is different from tune frequency.

Let me try to explain this code: 
- apply only to DVB-T;
- it will run when the read of NIT only found one frequency, thus transponder count == 1;
- will not run when the read of NIT found multiple frequencies;
- when the NIT found frequency is missing or different from the tuned frequency, it is obvious a error, because it would be stupid to have 1 frequency to read the NIT and a different frequency for the services;