### PR TITLE
lcn precedence

### DIFF
--- a/AutoBouquetsMaker/src/scanner/dvbscanner.py
+++ b/AutoBouquetsMaker/src/scanner/dvbscanner.py
@@ -304,7 +304,11 @@ class DvbScanner():
 				key = "%x:%x:%x" % (transponder["transport_stream_id"], transponder["original_network_id"], transponder["service_id"])
 				service_dict_tmp[key] = transponder
 				continue
-			if "descriptor_tag" in transponder and transponder["descriptor_tag"] in {0x82, 0x83}: # lcn
+			if "descriptor_tag" in transponder and transponder["descriptor_tag"] == 0x83: # lcn
+				key = "%x:%x:%x" % (transponder["transport_stream_id"], transponder["original_network_id"], transponder["service_id"])
+				logical_channel_number_dict_tmp[key] = transponder
+				continue
+			if "descriptor_tag" in transponder and transponder["descriptor_tag"] == 0x82: # lcn 0x82
 				key = "%x:%x:%x" % (transponder["transport_stream_id"], transponder["original_network_id"], transponder["service_id"])
 				logical_channel_number_dict_tmp[key] = transponder
 				continue


### PR DESCRIPTION
>So the code you sent is taking LCN from 2 different descriptors at the same time. That is bad. As said above `in (0x82, 0x83)` is wrong code. The LCN for each provider should come from one descriptor only. That code will need changing.

_Originally posted by @Huevos in https://github.com/oe-alliance/AutoBouquetsMaker/issues/244#issuecomment-1253039365_