### PR TITLE
When "Add provider name to bouquets" is enabled the " - All channels" should be omitted

### DIFF
--- a/AutoBouquetsMaker/src/scanner/bouquetswriter.py
+++ b/AutoBouquetsMaker/src/scanner/bouquetswriter.py
@@ -617,7 +617,7 @@ class BouquetsWriter():
 		if provider_config.isMakeNormalMain():
 			bouquet_current = open(path + "/%s%s.main.tv" % (self.ABM_BOUQUET_PREFIX, section_identifier), "w")
 			current_bouquet_list = []
-			current_bouquet_list.append("#NAME %s%s%s\n" % (section_prefix, section_sep, _('All channels')))
+			current_bouquet_list.append("#NAME %s%s\n" % (section_prefix, "" if config.autobouquetsmaker.addprefix and len(section_prefix) > 0 else section_sep + _('All channels')))
 
 			# Clear unused sections
 			sections_c = sections.copy()

--- a/AutoBouquetsMaker/src/scanner/bouquetswriter.py
+++ b/AutoBouquetsMaker/src/scanner/bouquetswriter.py
@@ -617,7 +617,7 @@ class BouquetsWriter():
 		if provider_config.isMakeNormalMain():
 			bouquet_current = open(path + "/%s%s.main.tv" % (self.ABM_BOUQUET_PREFIX, section_identifier), "w")
 			current_bouquet_list = []
-			current_bouquet_list.append("#NAME %s%s\n" % (section_prefix, "" if config.autobouquetsmaker.addprefix and len(section_prefix) > 0 else section_sep + _('All channels')))
+			current_bouquet_list.append("#NAME %s%s\n" % (section_prefix, "" if len(section_prefix) > 0 else _('All channels')))
 
 			# Clear unused sections
 			sections_c = sections.copy()

--- a/AutoBouquetsMaker/src/scanner/bouquetswriter.py
+++ b/AutoBouquetsMaker/src/scanner/bouquetswriter.py
@@ -617,7 +617,7 @@ class BouquetsWriter():
 		if provider_config.isMakeNormalMain():
 			bouquet_current = open(path + "/%s%s.main.tv" % (self.ABM_BOUQUET_PREFIX, section_identifier), "w")
 			current_bouquet_list = []
-			current_bouquet_list.append("#NAME %s%s\n" % (section_prefix, "" if len(section_prefix) > 0 else _('All channels')))
+			current_bouquet_list.append("#NAME %s%s\n" % (section_prefix, "" if len(section_prefix) > 0 and provider_config.flags == 1  else section_sep + _('All channels')))
 
 			# Clear unused sections
 			sections_c = sections.copy()

--- a/AutoBouquetsMaker/src/scanner/bouquetswriter.py
+++ b/AutoBouquetsMaker/src/scanner/bouquetswriter.py
@@ -576,8 +576,7 @@ class BouquetsWriter():
 		del avoid_duplicates
 
 	def buildBouquets(self, path, provider_config, services, sections, section_identifier, preferred_order, bouquets_to_hide, section_prefix):
-		if len(section_prefix) > 0:
-			section_prefix = section_prefix + " - "
+		section_sep = " - " if len(section_prefix) > 0 else ""
 		current_number = 0
 
 		# as first thing we're going to cleanup channels
@@ -618,7 +617,7 @@ class BouquetsWriter():
 		if provider_config.isMakeNormalMain():
 			bouquet_current = open(path + "/%s%s.main.tv" % (self.ABM_BOUQUET_PREFIX, section_identifier), "w")
 			current_bouquet_list = []
-			current_bouquet_list.append("#NAME %s%s\n" % (section_prefix, _('All channels')))
+			current_bouquet_list.append("#NAME %s%s%s\n" % (section_prefix, section_sep, _('All channels')))
 
 			# Clear unused sections
 			sections_c = sections.copy()
@@ -635,7 +634,7 @@ class BouquetsWriter():
 			# Always write first not hidden section on top of list
 			for number in preferred_order_tmp:
 				if number in sections_c and number not in bouquets_to_hide:
-					current_bouquet_list.append(self.styledBouquetMarker("%s%s" % (section_prefix, sections_c[number])))
+					current_bouquet_list.append(self.styledBouquetMarker("%s%s%s" % (section_prefix, section_sep, sections_c[number])))
 					first_section = number
 					break
 
@@ -643,7 +642,7 @@ class BouquetsWriter():
 			section_number = 1
 			for number in preferred_order_tmp:
 				if section_number in sections_c and section_number not in bouquets_to_hide and section_number != first_section:
-					current_bouquet_list.append(self.styledBouquetMarker("%s%s" % (section_prefix, sections_c[section_number])))
+					current_bouquet_list.append(self.styledBouquetMarker("%s%s%s" % (section_prefix, section_sep, sections_c[section_number])))
 				if provider_config.isSwapChannels() and number in swapDict:
 					number = swapDict[number]
 				if number in services["video"] and number not in bouquets_to_hide:
@@ -663,10 +662,10 @@ class BouquetsWriter():
 			current_bouquet_list = []
 			if provider_config.isMakeHDMain():
 				hd_or_ftahd = "HD"
-				current_bouquet_list.append("#NAME %s%s\n" % (section_prefix, _('HD Channels')))
+				current_bouquet_list.append("#NAME %s%s%s\n" % (section_prefix, section_sep, _('HD Channels')))
 			elif provider_config.isMakeFTAHDMain():
 				hd_or_ftahd = "FTAHD"
-				current_bouquet_list.append("#NAME %s%s\n" % (section_prefix, _('FTA HD Channels')))
+				current_bouquet_list.append("#NAME %s%s%s\n" % (section_prefix, section_sep, _('FTA HD Channels')))
 
 			higher_number = sorted(list(sections.keys()))[0]
 
@@ -684,7 +683,7 @@ class BouquetsWriter():
 						todo = None
 						if section_key_current not in bouquets_to_hide:
 							if section_key_current in sections_c:
-								current_bouquet_list.append(self.styledBouquetMarker("%s%s" % (section_prefix, sections_c[section_key_current])))
+								current_bouquet_list.append(self.styledBouquetMarker("%s%s%s" % (section_prefix, section_sep, sections_c[section_key_current])))
 							todo = section_key_current
 
 						if section_key_current in section_keys_temp:
@@ -748,12 +747,12 @@ class BouquetsWriter():
 				bouquet_current = open(path + "/%s%s.%d.tv" % (self.ABM_BOUQUET_PREFIX, section_identifier, section_number), "w")
 				current_bouquet_list = []
 				if section_number not in bouquets_to_hide:
-					current_bouquet_list.append("#NAME %s%s\n" % (section_prefix, section_name))
-					current_bouquet_list.append(self.styledBouquetMarker("%s%s" % (section_prefix, section_name)))
+					current_bouquet_list.append("#NAME %s%s%s\n" % (section_prefix, section_sep, section_name))
+					current_bouquet_list.append(self.styledBouquetMarker("%s%s%s" % (section_prefix, section_sep, section_name)))
 				elif section_current_number == 0:
-					current_bouquet_list.append("#NAME %sHidden\n" % section_prefix)
+					current_bouquet_list.append("#NAME %s%sHidden\n" % (section_prefix, section_sep))
 					current_bouquet_list.append("#SERVICE 1:64:0:0:0:0:0:0:0:0:\n")
-					current_bouquet_list.append("#DESCRIPTION %sHidden\n" % section_prefix)
+					current_bouquet_list.append("#DESCRIPTION %s%sHidden\n" % (section_prefix, section_sep))
 
 				#current_number += 1
 				section_current_number += 1
@@ -780,9 +779,9 @@ class BouquetsWriter():
 			provider_config.isMakeCustomMain():
 			bouquet_current = open(path + "/%s%s.separator.tv" % (self.ABM_BOUQUET_PREFIX, section_identifier), "w")
 			current_bouquet_list = []
-			current_bouquet_list.append("#NAME %sSeparator\n" % section_prefix)
+			current_bouquet_list.append("#NAME %s%sSeparator\n" % (section_prefix, section_sep))
 			current_bouquet_list.append("#SERVICE 1:64:0:0:0:0:0:0:0:0:\n")
-			current_bouquet_list.append("#DESCRIPTION %sSeparator\n" % section_prefix)
+			current_bouquet_list.append("#DESCRIPTION %s%sSeparator\n" % (section_prefix, section_sep))
 
 			for x in list(range(current_number, (int(current_number / 1000) + 1) * 1000)):
 				current_bouquet_list.append(self.spacer())
@@ -796,7 +795,7 @@ class BouquetsWriter():
 		if provider_config.isMakeHD():
 			bouquet_current = open(path + "/%s%s.hd.tv" % (self.ABM_BOUQUET_PREFIX, section_identifier), "w")
 			current_bouquet_list = []
-			current_bouquet_list.append("#NAME %s%s\n" % (section_prefix, _('HD Channels')))
+			current_bouquet_list.append("#NAME %s%s%s\n" % (section_prefix, section_sep, _('HD Channels')))
 
 			# Clear unused sections
 			sections_c = sections.copy()
@@ -811,7 +810,7 @@ class BouquetsWriter():
 					todo = None
 					if section_key_current not in bouquets_to_hide:
 						if section_key_current in sections_c:
-							current_bouquet_list.append(self.styledBouquetMarker("%s%s" % (section_prefix, sections_c[section_key_current])))
+							current_bouquet_list.append(self.styledBouquetMarker("%s%s%s" % (section_prefix, section_sep, sections_c[section_key_current])))
 						todo = section_key_current
 
 					if section_key_current in section_keys_temp:
@@ -839,7 +838,7 @@ class BouquetsWriter():
 		if provider_config.isMakeFTAHD():
 			bouquet_current = open(path + "/%s%s.ftahd.tv" % (self.ABM_BOUQUET_PREFIX, section_identifier), "w")
 			current_bouquet_list = []
-			current_bouquet_list.append("#NAME %s%s\n" % (section_prefix, _('FTA HD Channels')))
+			current_bouquet_list.append("#NAME %s%s%s\n" % (section_prefix, section_sep, _('FTA HD Channels')))
 
 			# Clear unused sections
 			sections_c = sections.copy()
@@ -854,7 +853,7 @@ class BouquetsWriter():
 					todo = None
 					if section_key_current not in bouquets_to_hide:
 						if section_key_current in sections_c:
-							current_bouquet_list.append(self.styledBouquetMarker("%s%s" % (section_prefix, sections_c[section_key_current])))
+							current_bouquet_list.append(self.styledBouquetMarker("%s%s%s" % (section_prefix, section_sep, sections_c[section_key_current])))
 						todo = section_key_current
 
 					if section_key_current in section_keys_temp:
@@ -882,7 +881,7 @@ class BouquetsWriter():
 		if provider_config.isMakeFTA():
 			bouquet_current = open(path + "/%s%s.fta.tv" % (self.ABM_BOUQUET_PREFIX, section_identifier), "w")
 			current_bouquet_list = []
-			current_bouquet_list.append("#NAME %s%s\n" % (section_prefix, _('FTA Channels')))
+			current_bouquet_list.append("#NAME %s%s%s\n" % (section_prefix, section_sep, _('FTA Channels')))
 
 			# Clear unused sections
 			sections_c = sections.copy()
@@ -899,7 +898,7 @@ class BouquetsWriter():
 					todo = None
 					if section_key_current not in bouquets_to_hide:
 						if section_key_current in sections_c:
-							current_bouquet_list.append(self.styledBouquetMarker("%s%s" % (section_prefix, sections_c[section_key_current])))
+							current_bouquet_list.append(self.styledBouquetMarker("%s%s%s" % (section_prefix, section_sep, sections_c[section_key_current])))
 						todo = section_key_current
 
 					if section_key_current in section_keys_temp:
@@ -926,8 +925,8 @@ class BouquetsWriter():
 		# now the radio bouquet
 		bouquet_current = open(path + "/%s%s.main.radio" % (self.ABM_BOUQUET_PREFIX, section_identifier), "w")
 		current_bouquet_list = []
-		current_bouquet_list.append("#NAME %s%s\n" % (section_prefix, _('Radio Channels')))
-		current_bouquet_list.append(self.styledBouquetMarker("%s%s" % (section_prefix, _('Radio Channels'))))
+		current_bouquet_list.append("#NAME %s%s%s\n" % (section_prefix, section_sep, _('Radio Channels')))
+		current_bouquet_list.append(self.styledBouquetMarker("%s%s%s" % (section_prefix, section_sep, _('Radio Channels'))))
 
 		if len(list(services["radio"].keys())) > 0:
 			higher_number = sorted(list(services["radio"].keys()))[-1]	# the highest number!

--- a/AutoBouquetsMaker/src/scanner/bouquetswriter.py
+++ b/AutoBouquetsMaker/src/scanner/bouquetswriter.py
@@ -617,7 +617,7 @@ class BouquetsWriter():
 		if provider_config.isMakeNormalMain():
 			bouquet_current = open(path + "/%s%s.main.tv" % (self.ABM_BOUQUET_PREFIX, section_identifier), "w")
 			current_bouquet_list = []
-			current_bouquet_list.append("#NAME %s%s\n" % (section_prefix, "" if len(section_prefix) > 0 and provider_config.flags == 1  else section_sep + _('All channels')))
+			current_bouquet_list.append("#NAME %s%s\n" % (section_prefix, "" if len(section_prefix) > 0 and (provider_config.flags & 0xdf) == 1 else section_sep + _('All channels')))
 
 			# Clear unused sections
 			sections_c = sections.copy()


### PR DESCRIPTION
When "Add provider name to bouquets" is enabled the " - All channels" should be omitted, it make sense only when the bouquet is a subset of All channels.