### PR TITLE
allow workflow to recurse into subdirectories

### DIFF
--- a/.github/workflows/autobouquetsmaker.yml
+++ b/.github/workflows/autobouquetsmaker.yml
@@ -42,7 +42,7 @@ jobs:
           autoreconf -i
           ./configure
           make
-          python -m compileall -l .
+          python -m compileall .
 
       - name: Check format PEP8
         run: |


### PR DESCRIPTION
python -m compileall -l flag was included by mistake from copying AutoBouquets workflow, doh!