### PR TITLE
Movistar+ 19.2 missing channels

### DIFF
--- a/AutoBouquetsMaker/lib/dvbreader.c
+++ b/AutoBouquetsMaker/lib/dvbreader.c
@@ -414,6 +414,28 @@ PyObject *ss_parse_bat(unsigned char *data, int length) {
 					descriptor_length -= 4;
 				}
 			}
+			else if (descriptor_tag == 0x82)	// LCN descriptor (Movistar+ SD, 19.2E)
+			{
+				while (descriptor_length > 0)
+				{
+					int service_id = (data[offset3] << 8) | data[offset3 + 1];
+					int logical_channel_number = (data[offset3 + 2] << 8) | data[offset3 + 3];
+
+					PyObject *item = Py_BuildValue("{s:i,s:i,s:i,s:i,s:i,s:i}",
+							"bouquet_id", bouquet_id,
+							"transport_stream_id", transport_stream_id,
+							"original_network_id", original_network_id,
+							"service_id", service_id,
+							"logical_channel_number", logical_channel_number,
+							"descriptor_tag", descriptor_tag);
+
+					PyList_Append(list, item);
+					Py_DECREF(item);
+					
+					offset3 += 4;
+					descriptor_length -= 4;
+				}
+			}
 			else if (descriptor_tag == 0x83)	// LCN descriptor (NC+, 13E)
 			{
 				while (descriptor_length > 0)

--- a/AutoBouquetsMaker/providers/sat_192_movistar_plus_esp.xml
+++ b/AutoBouquetsMaker/providers/sat_192_movistar_plus_esp.xml
@@ -55,13 +55,6 @@ blacklist = (
 if service["number"] > 500 or service["service_name"] in blacklist:
 	skip.skip = True
 
-# Remove duplicated SD services
-if service["service_type"] == 1 and service["number"] < 120:
-	for sid in tmp_services_dict:
-		if tmp_services_dict[sid]["number"] == service["number"] and tmp_services_dict[sid]["service_type"] == 25:
-			skip.skip = True
-			break
-
 ]]>
 	</servicehacks>
 </provider>

--- a/AutoBouquetsMaker/providers/sat_192_movistar_plus_esp.xml
+++ b/AutoBouquetsMaker/providers/sat_192_movistar_plus_esp.xml
@@ -19,22 +19,42 @@
 		onid="1"
 	/>
 	<dvbsconfigs>
+		<configuration key="sd_1" bouquet="0x21" region="0x82">Movistar+ SD</configuration>
 		<configuration key="hd_1" bouquet="0x21" region="0x83">Movistar+ HD</configuration>
+		<configuration key="hd_2" bouquet="0x21" region="0xFF">Movistar+ HD+SD</configuration>
 	</dvbsconfigs>
 	<sections>
-		<section number="1">Entretenimiento</section>
-		<section number="31">Pelis</section>
-		<section number="46">Deportes</section>
-		<section number="70">Documentales</section>
-		<section number="94">Infantil</section>
-		<section number="119">Noticias</section>
-		<section number="167">Taquilla</section>
-		<section number="400">No HD</section>
-		<section number="470">Otros</section>
+		<section number="1">Generalistas</section>
+		<section number="12">Originales</section>
+		<section number="30">Cine y Series</section>
+		<section number="53">Deportes</section>
+		<section number="82">Documentales</section>
+		<section number="92">Estilo de Vida</section>
+		<section number="110">Infantiles</section>
+		<section number="120">Música</section>
+		<section number="127">Noticias</section>
+		<section number="151">Autonómicos</section>
+		<section number="162">Alquiler SD</section>
+		<section number="167">Multideporte</section>
+		<section number="198">Alquiler HD</section>
+		<section number="199">Portada</section>
+		<section number="300">Bares</section>
+		<section number="400">SD</section>
+		<section number="485">Otros</section>
 	</sections>
 	<visibleserviceflag ignore="1"/>
 	<servicehacks>
 <![CDATA[
+
+# Remove invalid channels
+blacklist = (
+			".",
+			"TEST TÉCNICO"
+            )
+
+if service["number"] > 500 or service["service_name"] in blacklist:
+	skip.skip = True
+
 ]]>
 	</servicehacks>
 </provider>

--- a/AutoBouquetsMaker/providers/sat_192_movistar_plus_esp.xml
+++ b/AutoBouquetsMaker/providers/sat_192_movistar_plus_esp.xml
@@ -55,6 +55,13 @@ blacklist = (
 if service["number"] > 500 or service["service_name"] in blacklist:
 	skip.skip = True
 
+# Remove duplicated SD services
+if service["service_type"] == 1 and service["number"] < 120:
+	for sid in tmp_services_dict:
+		if tmp_services_dict[sid]["number"] == service["number"] and tmp_services_dict[sid]["service_type"] == 25:
+			skip.skip = True
+			break
+
 ]]>
 	</servicehacks>
 </provider>


### PR DESCRIPTION
- Changes to dvbreader to parse required region 0x82.
- Support to process multiple regions for a single provider (required for Movistar+). This is achieved with a new special descriptor_tag 0xFF. Duplicates are managed by defining a processing priority per region. For Movistar, 0x83 takes priority over 0x82.
- Updates to provider file.

This pull request overrides #277 and fixes missing channels reported here: https://github.com/oe-alliance/AutoBouquetsMaker/issues/276#issuecomment-1724630961
