### PR TITLE
Movistar+ multiple regions

### DIFF
--- a/AutoBouquetsMaker/providers/sat_192_movistar_plus_esp.xml
+++ b/AutoBouquetsMaker/providers/sat_192_movistar_plus_esp.xml
@@ -1,5 +1,5 @@
 <provider>
-	<name>Movistar+ Esp</name>
+	<name>Movistar+</name>
 	<streamtype>dvbs</streamtype>
 	<protocol>lcnbat2</protocol>
 	<transponder
@@ -19,22 +19,41 @@
 		onid="1"
 	/>
 	<dvbsconfigs>
-		<configuration key="hd_1" bouquet="0x21" region="0x83">Movistar+ HD</configuration>
+		<configuration key="hd_1" bouquet="0x21" region="0x82">Movistar+</configuration>
 	</dvbsconfigs>
 	<sections>
-		<section number="1">Entretenimiento</section>
-		<section number="31">Pelis</section>
-		<section number="46">Deportes</section>
-		<section number="70">Documentales</section>
-		<section number="94">Infantil</section>
-		<section number="119">Noticias</section>
-		<section number="167">Taquilla</section>
-		<section number="400">No HD</section>
-		<section number="470">Otros</section>
+		<section number="1">Generalistas</section>
+		<section number="12">Originales</section>
+		<section number="30">Cine y Series</section>
+		<section number="51">Deportes</section>
+		<section number="82">Documentales</section>
+		<section number="92">Estilo de Vida</section>
+		<section number="110">Infantiles</section>
+		<section number="120">Música</section>
+		<section number="127">Noticias</section>
+		<section number="151">Autonómicos</section>
+		<section number="162">Alquiler SD</section>
+		<section number="167">Multideporte</section>
+		<section number="198">Alquiler HD</section>
+		<section number="199">Portada</section>
+		<section number="300">Bares</section>
+		<section number="400">SD</section>
+		<section number="485">Otros</section>
 	</sections>
-	<visibleserviceflag ignore="1"/>
 	<servicehacks>
 <![CDATA[
+
+# Remove invalid channels
+blacklist = (
+			".",
+			"TEST TÉCNICO",
+			"BAJO DEMANDA",
+			"GUÍA"
+            )
+
+if service["number"] > 500 or service["service_name"] in blacklist:
+	skip.skip = True
+
 ]]>
 	</servicehacks>
 </provider>

--- a/AutoBouquetsMaker/providers/sat_192_movistar_plus_esp_0x83.xml
+++ b/AutoBouquetsMaker/providers/sat_192_movistar_plus_esp_0x83.xml
@@ -1,0 +1,37 @@
+<provider>
+	<name>Movistar+</name>
+	<dependent>sat_192_movistar_plus_esp</dependent>
+	<streamtype>dvbs</streamtype>
+	<protocol>lcnbat2</protocol>
+	<transponder
+		orbital_position="192"
+		frequency="10729000"
+		symbol_rate="22000000"
+		polarization="1"
+		fec_inner="2"
+		inversion="2"
+		system="1"
+		modulation="2"
+		roll_off="0"
+		pilot="2"
+		nit_other_table_id="0x00"
+		bat_pid="0x11"
+		tsid="1050"
+		onid="1"
+	/>
+	<dvbsconfigs>
+		<configuration key="hd_1" bouquet="0x21" region="0x83">Movistar+ HD</configuration>
+	</dvbsconfigs>
+	<sections>
+		<section number="1">Movistar+</section>
+	</sections>
+	<visibleserviceflag ignore="1"/>
+	<servicehacks>
+<![CDATA[
+
+if service["number"] > 500:
+	skip.skip = True
+
+]]>
+	</servicehacks>
+</provider>


### PR DESCRIPTION
Changes to provider files to support region 0x82 and merge with 0x83. This produces official channel order. This is now achieved without code changes.