### PR TITLE
Update sat_192_movistar_plus_esp.xml

### DIFF
--- a/AutoBouquetsMaker/providers/sat_192_movistar_plus_esp.xml
+++ b/AutoBouquetsMaker/providers/sat_192_movistar_plus_esp.xml
@@ -27,7 +27,7 @@
 		<section number="1">Generalistas</section>
 		<section number="12">Originales</section>
 		<section number="30">Cine y Series</section>
-		<section number="53">Deportes</section>
+		<section number="52">Deportes</section>
 		<section number="82">Documentales</section>
 		<section number="92">Estilo de Vida</section>
 		<section number="110">Infantiles</section>


### PR DESCRIPTION
Small fix to correct start channel number of sports bouquets (from 53 to 52).