### PR TITLE
[28.2E] London Live channel number outside London.

### DIFF
--- a/AutoBouquetsMaker/providers/sat_282_sky_irl.xml
+++ b/AutoBouquetsMaker/providers/sat_282_sky_irl.xml
@@ -152,7 +152,7 @@ except:
 	########################################################################
 
 	channels_to_add_by_name = {
-		"London Live": 117 #This is only added if you do not have an official local 117 service
+		"London Live": 197 #This is only added if you do not have an official local 197 service
 	}
 
 	channels_to_add_by_id = {

--- a/AutoBouquetsMaker/providers/sat_282_sky_irl.xml
+++ b/AutoBouquetsMaker/providers/sat_282_sky_irl.xml
@@ -152,7 +152,7 @@ except:
 	########################################################################
 
 	channels_to_add_by_name = {
-		"London Live": 173 #This is only added if you do not have an official local 173 service
+		"London Live": 197 #This is only added if you do not have an official local 197 service
 	}
 
 	channels_to_add_by_id = {

--- a/AutoBouquetsMaker/providers/sat_282_sky_uk.xml
+++ b/AutoBouquetsMaker/providers/sat_282_sky_uk.xml
@@ -333,7 +333,7 @@ except:
 	########################################################################
 
 	channels_to_add_by_name = {
-		"London Live": 117 #This is only added if you do not have an official local 117 service
+		"London Live": 197 #This is only added if you do not have an official local 197 service
 	}
 
 	channels_to_add_by_id = {

--- a/AutoBouquetsMaker/providers/sat_282_sky_uk.xml
+++ b/AutoBouquetsMaker/providers/sat_282_sky_uk.xml
@@ -333,7 +333,7 @@ except:
 	########################################################################
 
 	channels_to_add_by_name = {
-		"London Live": 173 #This is only added if you do not have an official local 173 service
+		"London Live": 197 #This is only added if you do not have an official local 197 service
 	}
 
 	channels_to_add_by_id = {


### PR DESCRIPTION
Change the channel number where London Live is inserted when outside London from 173 to 117. 173 now seems to be occupied, at least for normal English viewers.