### PR TITLE
Updates to Movistar provider file (November 2025)

### DIFF
--- a/AutoBouquetsMaker/providers/sat_192_movistar_plus_esp.xml
+++ b/AutoBouquetsMaker/providers/sat_192_movistar_plus_esp.xml
@@ -25,9 +25,9 @@
 	</dvbsconfigs>
 	<sections>
 		<section number="1">Generalistas</section>
-		<section number="12">Originales</section>
+		<section number="7">Originales</section>
 		<section number="30">Cine y Series</section>
-		<section number="52">Deportes</section>
+		<section number="50">Deportes</section>
 		<section number="82">Documentales</section>
 		<section number="92">Estilo de Vida</section>
 		<section number="110">Infantiles</section>


### PR DESCRIPTION
Change to Sports bouquet location (from 52 to 50), required to accomodate recent changes from provider.
Fix to Originals bouquet to include additional propietary provider channels, previously under "Generalist".